### PR TITLE
[TEST] api/vi/users/start 와 api/v1/pets/nickname 테스트 코드 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 MODEL_PATH=./model/emotion_model.pkl
+TIMEZONE=Asia/Seoul
+# DATABASE_URL=postgresql+psycopg2://postgres:[yourpassword]@localhost:5432/nosogong_db

--- a/README.md
+++ b/README.md
@@ -121,3 +121,5 @@ pip install -r requirements.txt
 ```bash
 CREATE DATABASE nosogong_db;
 ```
+## .env.example
+.env.example을 .env로 복사해서 사용하기

--- a/app/api/user/repository.py
+++ b/app/api/user/repository.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from app.models.user import User
 from uuid import uuid4
 from datetime import datetime
+from app.core.config import KST
 
 def insert_user(db: Session) -> User: # 데이터베이스에 유저를 추가하는 쿼리
      # 유저가 이미 하나라도 있으면 새로 생성하지 않음
@@ -9,8 +10,10 @@ def insert_user(db: Session) -> User: # 데이터베이스에 유저를 추가�
     if existing_user:
         return existing_user
 
+    now_kst = datetime.now(KST)
+
     # 유저가 없으면 새로 생성
-    new_user = User(userId=uuid4(), createdAt=datetime.utcnow(), money=0)
+    new_user = User(userId=uuid4(), createdAt=now_kst, money=0) # KST 기준으로 DB에 createAt 을 저장
     db.add(new_user)
     db.commit()
     db.refresh(new_user)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,10 @@
+# app/core/config.py
+
+import os
+from dotenv import load_dotenv
+from pytz import timezone
+
+load_dotenv()
+
+TIMEZONE = os.getenv("TIMEZONE", "Asia/Seoul")
+KST = timezone(TIMEZONE)

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -28,7 +28,7 @@ Base = declarative_base()
 metadata = MetaData()
 
 def get_db():
-    db: Session = SessionLocal()    # DB 세션 하나 생성
+    db = SessionLocal()    # DB 세션 하나 생성
     try:
         yield db                    # 세션을 외부에 "빌려줌"
     finally:

--- a/app/main.py
+++ b/app/main.py
@@ -42,16 +42,16 @@ app.include_router(pet_router)
 app.include_router(user_router)
 
 # 서버가 실행되면 자동으로 "http://localhost:8000/api/v1/users/start"로 post를 보내서 유저 자동 생성
-def call_start_api_after_server_ready():
-    # 서버가 완전히 켜질 때까지 잠깐 기다림
-    time.sleep(1.5)  # 상황에 따라 1~2초로 조절
-    try:
-        response = requests.post("http://localhost:8000/api/v1/users/start")
-        print(f"✅ /start API 호출 성공: {response.status_code}, {response.json()}")
-    except Exception as e:
-        print(f"❌ /start API 호출 실패: {e}")
+# def call_start_api_after_server_ready():
+#     # 서버가 완전히 켜질 때까지 잠깐 기다림
+#     time.sleep(1.5)  # 상황에 따라 1~2초로 조절
+#     try:
+#         response = requests.post("http://localhost:8000/api/v1/users/start")
+#         print(f"✅ /start API 호출 성공: {response.status_code}, {response.json()}")
+#     except Exception as e:
+#         print(f"❌ /start API 호출 실패: {e}")
 
-@app.on_event("startup")
+@app.on_event("startup") # 서버 실행시
 def on_startup():
     Base.metadata.create_all(bind=engine)                               # 테이블 자동 생성(python create_tables.py 와 동일)
-    threading.Thread(target=call_start_api_after_server_ready).start()  # call_start_api_after_server_ready() 함수 호출을 통해 유저 생성
+    # threading.Thread(target=call_start_api_after_server_ready).start()  # call_start_api_after_server_ready() 함수 호출을 통해 유저 생성

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,44 @@
+# tests/conftest.py
+
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.core.database import engine, SessionLocal
+from sqlalchemy.orm import Session
+from uuid import uuid4
+import sqlalchemy
+from app.core.database import get_db
+from app.core.config import KST
+
+# 실제 DB를 쓰되, 트랜잭션을 롤백하기 위한 fixture
+@pytest.fixture(scope="function")
+def db_session():
+    connection = engine.connect()
+    transaction = connection.begin()
+
+    session = Session(bind=connection)
+    session.begin_nested()
+
+    # 트랜잭션 이벤트 리스너 등록 → SAVEPOINT rollback 방지용
+    @sqlalchemy.event.listens_for(session, "after_transaction_end")
+    def restart_savepoint(sess, trans):
+        if trans.nested and not trans._parent.nested:
+            session.begin_nested()
+
+    yield session  # 이 안에서 테스트가 실행됨
+
+    session.close()
+    transaction.rollback()  # 테스트 끝나면 변경사항을 되돌림
+    connection.close()
+
+# FastAPI의 get_db 의존성 오버라이드
+@pytest.fixture(scope="function")
+def client(db_session):
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides = {}
+    app.dependency_overrides[get_db] = override_get_db
+
+    return TestClient(app)
+

--- a/app/tests/pet/test_pet.py
+++ b/app/tests/pet/test_pet.py
@@ -1,0 +1,36 @@
+# tests/user/test_user.py
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+# 동물 이름 지어주기 테스트
+def test_nickname_animals(client):
+
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+
+    # 생성된 유저 ID 사용
+    user_id = user_response.json()["userId"]
+
+    payload = {
+        "animals": [
+            {"animalId": 1, "name": "시바"},
+            {"animalId": 2, "name": "꽥이"},
+            {"animalId": 3, "name": "삐약이"}
+        ]
+    }
+
+    response = client.post(
+        "/api/v1/pets/nickname",
+        json=payload,
+        headers={"user-id": user_id}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["message"] == "동물 이름이 성공적으로 저장되었습니다."
+    assert isinstance(data["data"], dict) or isinstance(data["data"], list)
+    assert data["status"] == 200

--- a/app/tests/user/test_user.py
+++ b/app/tests/user/test_user.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+# 사용자 생성 테스트
+def test_start_user_creation(client):
+    # API 요청
+    response = client.post("/api/v1/users/start")
+
+    # 응답 코드 검증
+    assert response.status_code == 201
+
+    # 응답 본문 파싱
+    data = response.json()
+
+    # 응답 필드 확인
+    assert "userId" in data
+    assert isinstance(data["userId"], str)

--- a/test_connection.py
+++ b/test_connection.py
@@ -1,14 +1,17 @@
 # test_connection.py
-import asyncio
-from app.core.database import database
 
-async def test_db_connection():
+from app.core.database import SessionLocal
+from sqlalchemy import text
+
+def test_db_connection():
     try:
-        await database.connect()
+        db = SessionLocal()
+        db.execute(text("SELECT 1"))
         print("✅ PostgreSQL 연결 성공!")
-        await database.disconnect()
     except Exception as e:
         print("❌ PostgreSQL 연결 실패:", e)
+    finally:
+        db.close()
 
 if __name__ == "__main__":
-    asyncio.run(test_db_connection())
+    test_db_connection()


### PR DESCRIPTION
## 주요 변경 사항

- [x] api/vi/users/start 테스트 코드 추가

- [x] api/v1/pets/nickname 테스트 코드 추가

## 세부 구현

-  tests 폴더 생성 후에 conftest.py 작성
-  두 api에 대해 test 코드 작성(각각 DB에서 테스트 진행 후에 롤백되도록 설정)
- api/v1/pets/nickname 테스트 코드의 경우, 내부적으로 api/vi/users/start로 사용자를 생성해서 userId를 받아서 api 테스트를 실행 후 롤백
---

Closes #4 