### PR TITLE
[FEAT] 현재 보유 코인 조회 기능 및 테스트 코드 추가

### DIFF
--- a/app/api/user/controller.py
+++ b/app/api/user/controller.py
@@ -1,8 +1,11 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, Header
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
-from app.api.user.schema import UserCreateResponse
-from app.api.user.service import create_user
+from app.api.user.schema import UserCreateResponse, UserPropertyResponse
+from app.api.user.service import create_user, get_user_property_service
+from app.core.exception import CustomException
 from app.core.database import get_db
+from uuid import UUID
 
 router = APIRouter(prefix="/api/v1/users", tags=["User"])
 
@@ -11,3 +14,22 @@ router = APIRouter(prefix="/api/v1/users", tags=["User"])
 def start_game(db: Session = Depends(get_db)):                                                  # 요청 시 DB 세션을 get_db() 함수로부터 주입받음 (의존성 주입).
     user = create_user(db)                                                                      # 서비스 레이어에서 실제 유저 생성 로직을 호출.
     return {"userId": user.userId}                                                              # 생성된 userId를 JSON으로 반환.
+
+# 사용자의 보유 코인을 조회하는 api
+@router.get("/property", response_model=UserPropertyResponse)
+def get_user_property(db: Session = Depends(get_db), user_id: UUID = Header(..., alias="user-id")):
+    try:
+        user = get_user_property_service(db, user_id)
+        if user is None:
+            raise CustomException("사용자 정보를 찾을 수 없습니다.", status=404)
+
+        return JSONResponse(
+            status_code=200,
+            content={
+                "money": user.money,
+                "message": "현재 보유 골드 조회 성공",
+                "status": 200
+            }
+        )
+    except CustomException as e:
+        raise e

--- a/app/api/user/repository.py
+++ b/app/api/user/repository.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 from app.models.user import User
-from uuid import uuid4
+from uuid import uuid4, UUID
 from datetime import datetime
 from app.core.config import KST
 
@@ -18,3 +18,6 @@ def insert_user(db: Session) -> User: # 데이터베이스에 유저를 추가�
     db.commit()
     db.refresh(new_user)
     return new_user
+
+def get_user_by_id(db: Session, user_id: UUID):
+    return db.query(User).filter(User.userId == user_id).first()

--- a/app/api/user/schema.py
+++ b/app/api/user/schema.py
@@ -4,3 +4,9 @@ from uuid import UUID
 # 유저 생성 응답 dto(/users/start)
 class UserCreateResponse(BaseModel):   
     userId: UUID
+
+# 유저 코인 조회 응답 dto(/user/property)
+class UserPropertyResponse(BaseModel):
+    money: int
+    message: str
+    status: int

--- a/app/api/user/service.py
+++ b/app/api/user/service.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
-from app.api.user.repository import insert_user
+from app.api.user.repository import insert_user, get_user_by_id
 from app.core.exception import CustomException
+from uuid import UUID
 
 # 유저 생성(/users/start)
 def create_user(db: Session):
@@ -9,3 +10,6 @@ def create_user(db: Session):
     except Exception as e:              # 예외 발생 시 400 응답과 메시지 반환
         raise CustomException(message = "서버 내부 오류로 인해 유저를 생성하지 못했습니다.", status = 400)
 
+# 코인 조회(/users/property)
+def get_user_property_service(db: Session, user_id: UUID):
+    return get_user_by_id(db, user_id)

--- a/app/tests/user/test_user.py
+++ b/app/tests/user/test_user.py
@@ -32,3 +32,8 @@ def test_user_property(client, db_session):
 
     response = client.get("/api/v1/users/property", headers={"user-id": str(user.userId)})
     assert response.status_code == 200
+
+    data = response.json()
+    assert data["money"] == 30
+    assert data["message"] == "현재 보유 골드 조회 성공"
+    assert data["status"] == 200

--- a/app/tests/user/test_user.py
+++ b/app/tests/user/test_user.py
@@ -1,5 +1,9 @@
 from fastapi.testclient import TestClient
 from app.main import app
+from app.models.user import User
+from uuid import uuid4
+from datetime import datetime
+from app.core.config import KST
 
 # 사용자 생성 테스트
 def test_start_user_creation(client):
@@ -15,3 +19,16 @@ def test_start_user_creation(client):
     # 응답 필드 확인
     assert "userId" in data
     assert isinstance(data["userId"], str)
+
+# 사용자 코인 조회 테스트(/users/property)
+def test_user_property(client, db_session):
+    user = User(
+        userId=uuid4(),
+        createdAt=datetime.now(KST),
+        money=30
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    response = client.get("/api/v1/users/property", headers={"user-id": str(user.userId)})
+    assert response.status_code == 200


### PR DESCRIPTION
## 기능 추가
- GET /api/v1/users/property: 현재 보유 코인(money)를 조회하는 API 구현
- 사용자 UUID는 헤더 `user-id`로 전달받고, 이를 기반으로 DB에서 해당 사용자의 자산 정보를 조회

## 테스트 코드 추가
- 테스트 파일: `tests/user/test_user.py`
- 테스트 내용:
  - 테스트용 User 객체를 직접 DB에 삽입
  - `user-id` 헤더를 통해 코인(money) 조회 요청
  - 응답 코드 및 응답 본문 내 money, message, status 필드 검증

closes #13 