### PR TITLE
[REFACTOR] event router prefix 변경

### DIFF
--- a/app/api/event/controller.py
+++ b/app/api/event/controller.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from app.core.exception import CustomException
 import traceback
 
-router = APIRouter(prefix="/api/v1/event", tags=["event"])
+router = APIRouter(prefix="/api/v1/events", tags=["event"])
 
 @router.get("/attendance", response_model=AttendanceResponse)
 def attendance_info(user_id: UUID = Header(..., alias="user-id"), db: Session = Depends(get_db)):


### PR DESCRIPTION
## 변경사항
- event 관련 라우터 prefix를 `/api/v1/event` → `/api/v1/events`로 수정