### PR TITLE
[FEAT] 동물 가출 처리 API(`POST /api/v1/pets/{animalId}/runaway`) 구현 및 테스트 코드 추가

### DIFF
--- a/app/api/event/controller.py
+++ b/app/api/event/controller.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from app.core.exception import CustomException
 import traceback
 
-router = APIRouter(prefix="/api/v1/event", tags=["event"])
+router = APIRouter(prefix="/api/v1/events", tags=["event"])
 
 @router.get("/attendance", response_model=AttendanceResponse)
 def attendance_info(user_id: UUID = Header(..., alias="user-id"), db: Session = Depends(get_db)):

--- a/app/api/pet/controller.py
+++ b/app/api/pet/controller.py
@@ -4,8 +4,8 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
-from app.api.pet.schema import AnimalNicknameRequest, AnimalNicknameResponse, AnimalInfoResponse
-from app.api.pet.service import register_pet_nicknames, get_pet_info_service
+from app.api.pet.schema import AnimalNicknameRequest, AnimalNicknameResponse, AnimalInfoResponse, AnimalRunawayResponse
+from app.api.pet.service import register_pet_nicknames, get_pet_info_service, handle_animal_runaway
 from app.core.exception import CustomException
 from uuid import UUID
 
@@ -34,3 +34,24 @@ def get_pet_info(animalId: int, db: Session = Depends(get_db) ,user_id: UUID = H
     if pet_info is None:
         raise CustomException(message = "해당 동물을 찾을 수 없습니다.", status=404)
     return pet_info    
+
+# 동물 가출 처리 api
+@router.post("/{animalId}/runaway", response_model=AnimalRunawayResponse)
+def runaway_pet(animalId: int, db: Session = Depends(get_db), user_id: UUID = Header(..., alias="user-id")):
+    """동물 가출 처리"""
+    try:
+        result = handle_animal_runaway(db, user_id, animalId)
+        
+        species_map = {1: "shiba", 2: "chick", 3: "duck"}
+        species_name = species_map.get(animalId, "unknown")
+        
+        return JSONResponse(
+            status_code=200,
+            content={
+                "message": f"{species_name} 동물이 성공적으로 가출 처리되었습니다.",
+                "data": result,
+                "status": 200
+            }
+        )
+    except CustomException as e:
+        raise e   # 커스텀 예외는 그대로 상위 예외 핸들러로 전달    

--- a/app/api/pet/repository.py
+++ b/app/api/pet/repository.py
@@ -40,6 +40,9 @@ def update_animal_runaway_status(db: Session, user_id: UUID, animal_id: int):
     
     if animal.isRunaway:
         raise CustomException("해당 동물은 이미 가출 상태입니다.", status=409)
+
+    if animal.currentEmotion != 0:
+        raise CustomException("현재 감정치가 0이 아니므로 가출 처리할 수 없습니다.", status=400)
     
     animal.isRunaway = True
     db.commit()

--- a/app/api/pet/repository.py
+++ b/app/api/pet/repository.py
@@ -28,4 +28,22 @@ def get_animal_by_user_and_id(db: Session, user_id: UUID, animal_id: int):
         Animal.animalId == animal_id
     ).first()
 
+# 동물 가출 상태 업데이트(/pets/{animalId}/runaway)
+def update_animal_runaway_status(db: Session, user_id: UUID, animal_id: int):
+    animal = db.query(Animal).filter(
+        Animal.userId == user_id,
+        Animal.animalId == animal_id
+    ).first()
+    
+    if animal is None:
+        raise CustomException("유효하지 않은 동물 ID입니다.", status=400)
+    
+    if animal.isRunaway:
+        raise CustomException("해당 동물은 이미 가출 상태입니다.", status=409)
+    
+    animal.isRunaway = True
+    db.commit()
+    db.refresh(animal)
+    return animal
+
 

--- a/app/api/pet/schema.py
+++ b/app/api/pet/schema.py
@@ -27,3 +27,9 @@ class AnimalInfoResponse(BaseModel):
     currentEmotion: int
     isRunaway: bool
     status: int    
+
+# 동물 가출 처리 응답(/pets/{animalId}/runaway)
+class AnimalRunawayResponse(BaseModel):
+    message: str
+    data: dict
+    status: int    

--- a/app/api/pet/service.py
+++ b/app/api/pet/service.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from datetime import date
 
 from app.api.pet.schema import AnimalInfoResponse
-from app.api.pet.repository import create_animal, get_animal_by_user_and_id
+from app.api.pet.repository import create_animal, get_animal_by_user_and_id, update_animal_runaway_status
 from app.core.exception import CustomException
 
 # 동물 이름 새로 지어주면서 만들기(/pets/nickname)
@@ -62,3 +62,12 @@ def get_pet_info_service(db: Session, user_id: UUID, animal_id: int) -> AnimalIn
         isRunaway=animal.isRunaway,
         status=200
     )
+
+# 동물 가출 처리(/pets/{animalId}/runaway)
+def handle_animal_runaway(db: Session, user_id: UUID, animal_id: int) -> Dict:
+    animal = update_animal_runaway_status(db, user_id, animal_id)
+    
+    return {
+        "animalId": animal.animalId,
+        "isRunaway": animal.isRunaway
+    }

--- a/app/tests/pet/test_pet.py
+++ b/app/tests/pet/test_pet.py
@@ -150,7 +150,7 @@ def test_runaway_pet_already_runaway(client, db_session):
 
     # 가출 조건 만족을 위해 감정치를 0으로 설정 (animalId: 1)
     animal = db_session.query(Animal).filter(Animal.userId == user_id, Animal.animalId == 1).first()
-    animal.currentEmotion = Decimal("0")
+    animal.currentEmotion = 0
     db_session.commit()
 
     # 첫 번째 가출 처리 (성공)
@@ -224,7 +224,7 @@ def test_runaway_pet_status_check(client, db_session):
 
     # 가출 조건 만족을 위해 감정치를 0으로 설정 (animalId: 3)
     animal = db_session.query(Animal).filter(Animal.userId == user_id, Animal.animalId == 3).first()
-    animal.currentEmotion = Decimal("0")
+    animal.currentEmotion = 0
     db_session.commit()
 
     # 가출 처리 전 상태 확인 (동물 정보 조회 API 사용)

--- a/app/tests/pet/test_pet.py
+++ b/app/tests/pet/test_pet.py
@@ -78,3 +78,163 @@ def test_get_animal_info(client):
     assert isinstance(data["currentEmotion"], int)
     assert isinstance(data["isRunaway"], bool)
     assert data["status"] == 200
+
+# 동물 가출 처리 성공 테스트(/pets/{animalId}/runaway)
+def test_runaway_pet_success(client):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+
+    # 생성된 유저 ID 사용
+    user_id = user_response.json()["userId"]
+
+    # 동물 이름 지어주기
+    payload = {
+        "animals": [
+            {"animalId": 1, "name": "시바"},
+            {"animalId": 2, "name": "꽥이"},
+            {"animalId": 3, "name": "삐약이"}
+        ]
+    }
+
+    nickname_response = client.post(
+        "/api/v1/pets/nickname",
+        json=payload,
+        headers={"user-id": user_id}
+    )
+    assert nickname_response.status_code == 200
+
+    # 가출 처리 요청 (chick - animalId: 2)
+    response = client.post(
+        "/api/v1/pets/2/runaway",
+        headers={"user-id": user_id}
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == 200
+    assert "chick 동물이 성공적으로 가출 처리되었습니다." in data["message"]
+    assert data["data"]["animalId"] == 2
+    assert data["data"]["isRunaway"] == True
+
+# 이미 가출 상태인 동물 가출 처리 시도 테스트
+def test_runaway_pet_already_runaway(client):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+
+    # 생성된 유저 ID 사용
+    user_id = user_response.json()["userId"]
+
+    # 동물 이름 지어주기
+    payload = {
+        "animals": [
+            {"animalId": 1, "name": "시바"},
+            {"animalId": 2, "name": "꽥이"},
+            {"animalId": 3, "name": "삐약이"}
+        ]
+    }
+
+    nickname_response = client.post(
+        "/api/v1/pets/nickname",
+        json=payload,
+        headers={"user-id": user_id}
+    )
+    assert nickname_response.status_code == 200
+
+    # 첫 번째 가출 처리 (성공)
+    first_runaway = client.post(
+        "/api/v1/pets/1/runaway",
+        headers={"user-id": user_id}
+    )
+    assert first_runaway.status_code == 200
+
+    # 두 번째 가출 처리 시도 (실패 - 이미 가출 상태)
+    second_runaway = client.post(
+        "/api/v1/pets/1/runaway",
+        headers={"user-id": user_id}
+    )
+    
+    assert second_runaway.status_code == 409
+    data = second_runaway.json()
+    assert data["status"] == 409
+    assert "해당 동물은 이미 가출 상태입니다." in data["message"]
+
+# 존재하지 않는 동물 ID로 가출 처리 시도 테스트
+def test_runaway_pet_invalid_animal_id(client):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+
+    # 생성된 유저 ID 사용
+    user_id = user_response.json()["userId"]
+
+    # 가출 처리 요청 (존재하지 않는 동물 ID)
+    response = client.post(
+        "/api/v1/pets/999/runaway",
+        headers={"user-id": user_id}
+    )
+    
+    assert response.status_code == 400
+    data = response.json()
+    assert data["status"] == 400
+    assert "유효하지 않은 동물 ID입니다." in data["message"]
+
+# 사용자 ID 헤더가 없는 경우 테스트
+def test_runaway_pet_missing_user_id(client):
+    response = client.post("/api/v1/pets/1/runaway")
+    
+    assert response.status_code == 422  # Validation error for missing header
+
+# 가출 처리 후 동물 상태 확인 테스트
+def test_runaway_pet_status_check(client):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+
+    # 생성된 유저 ID 사용
+    user_id = user_response.json()["userId"]
+
+    # 동물 이름 지어주기
+    payload = {
+        "animals": [
+            {"animalId": 1, "name": "시바"},
+            {"animalId": 2, "name": "꽥이"},
+            {"animalId": 3, "name": "삐약이"}
+        ]
+    }
+
+    nickname_response = client.post(
+        "/api/v1/pets/nickname",
+        json=payload,
+        headers={"user-id": user_id}
+    )
+    assert nickname_response.status_code == 200
+
+    # 가출 처리 전 상태 확인 (동물 정보 조회 API 사용)
+    before_response = client.get(
+        "/api/v1/pets/3",
+        headers={"user-id": user_id}
+    )
+    assert before_response.status_code == 200
+    before_data = before_response.json()
+    assert before_data["isRunaway"] == False  # 가출 처리 전에는 False
+
+    # 가출 처리
+    runaway_response = client.post(
+        "/api/v1/pets/3/runaway",
+        headers={"user-id": user_id}
+    )
+    assert runaway_response.status_code == 200
+
+    # 가출 처리 후 상태 확인 (GET /pets/{animalId}로 조회)
+    after_response = client.get(
+        "/api/v1/pets/3",
+        headers={"user-id": user_id}
+    )
+    assert after_response.status_code == 200
+    
+    after_data = after_response.json()
+    assert after_data["isRunaway"] == True  # 가출 처리 후에는 True
+    assert after_data["animalId"] == 3
+    


### PR DESCRIPTION
## 어떤 기능인가요?

- 동물 가출 처리 API(`POST /api/v1/pets/{animalId}/runaway`)

##  어떻게 구현하면 좋을까요?

구현 아이디어가 있다면 적어주세요.

##  작업 TODO

- [x] 동물 가출 처리 API(`POST /api/v1/pets/{animalId}/runaway`) 구현
- [x] 동물 가출 처리 API(`POST /api/v1/pets/{animalId}/runaway`) 테스트 코드 추가

## 다른 방법이 있을까요?

이 기능의 다른 해결 방법이나 대체 아이디어가 있다면 알려주세요.

##  추가 정보

closes #20 
