### PR TITLE
[FEAT] 게임 전체 설정 초기화(다시 시작) API(`POST /api/v1/ending/reset`) 구현 및 테스트 코드 추가

### DIFF
--- a/app/api/ending/controller.py
+++ b/app/api/ending/controller.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, Header
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+from uuid import UUID
+
+from app.core.database import get_db
+from app.core.exception import CustomException
+from app.api.ending.service import reset_game_service
+
+router = APIRouter(prefix="/api/v1/endings", tags=["Ending"])
+
+
+@router.post("/reset")
+def reset_game(user_id: UUID = Header(..., alias="user-id"), db: Session = Depends(get_db)):
+    try:
+        data = reset_game_service(db, user_id)
+        return JSONResponse(
+            status_code=200,
+            content={
+                "message": "게임 설정이 초기화되었습니다. 이름 짓는 화면으로 이동합니다.",
+                **data,
+                "status": 200,
+            },
+        )
+    except CustomException as e:
+        return JSONResponse(status_code=e.status, content={"message": e.message, "status": e.status})
+    except Exception:
+        return JSONResponse(status_code=500, content={"message": "게임 초기화 중 오류가 발생했습니다.", "status": 500})

--- a/app/api/ending/repository.py
+++ b/app/api/ending/repository.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+from sqlalchemy.orm import Session
+from sqlalchemy import delete
+
+from app.models.user import User
+from app.models.animal import Animal
+from app.models.moneyTransaction import MoneyTransaction
+from app.models.attendance import AttendanceLog
+from app.models.birthday import BirthdayReward
+
+
+def delete_user_and_related_data(db: Session, user_id: UUID):
+    # 연관 데이터 삭제 (동물, 트랜잭션, 출석, 생일 보상, 유저)
+    db.execute(delete(Animal).where(Animal.userId == user_id))
+    db.execute(delete(MoneyTransaction).where(MoneyTransaction.userId == user_id))
+    db.execute(delete(AttendanceLog).where(AttendanceLog.userId == user_id))
+    db.execute(delete(BirthdayReward).where(BirthdayReward.userId == user_id))
+    db.execute(delete(User).where(User.userId == user_id))
+    db.commit()
+
+
+def get_user_by_id(db: Session, user_id: UUID):
+    return db.query(User).filter(User.userId == user_id).first()

--- a/app/api/ending/schema.py
+++ b/app/api/ending/schema.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+
+class AnimalResetInfo(BaseModel):
+    animalId: int
+    name: Optional[str]
+    current_emotion: int
+    isRunaway: bool
+
+
+class ResetResponse(BaseModel):
+    message: str
+    money: int
+    animals: List[AnimalResetInfo]
+    totalPlayDays: int
+    totalUsedMoney: int
+    status: int

--- a/app/api/ending/service.py
+++ b/app/api/ending/service.py
@@ -1,0 +1,29 @@
+from uuid import UUID
+from sqlalchemy.orm import Session
+
+from app.core.exception import CustomException
+from app.api.ending.repository import get_user_by_id, delete_user_and_related_data
+
+
+def reset_game_service(db: Session, user_id: UUID):
+    user = get_user_by_id(db, user_id)
+    if not user:
+        raise CustomException(message="존재하지 않는 사용자입니다.", status=404)
+
+    try:
+        delete_user_and_related_data(db, user_id)
+    except Exception:
+        db.rollback()
+        raise
+
+    # 초기 상태 반환 스펙
+    return {
+        "money": 0,
+        "animals": [
+            {"animalId": 1, "name": None, "current_emotion": 50, "isRunaway": False},
+            {"animalId": 2, "name": None, "current_emotion": 50, "isRunaway": False},
+            {"animalId": 3, "name": None, "current_emotion": 50, "isRunaway": False},
+        ],
+        "totalPlayDays": 0,
+        "totalUsedMoney": 0,
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from create_tables import insert_initial_data
 from app.api.care.controller import router as care_router
 from app.api.pet.controller import router as pet_router
 from app.api.user.controller import router as user_router
+from app.api.ending.controller import router as ending_router
 from app.api.event.controller import router as event_router
 
 
@@ -44,6 +45,7 @@ app.include_router(care_router)
 app.include_router(pet_router)
 app.include_router(user_router)
 app.include_router(event_router)
+app.include_router(ending_router)
 
 # 서버가 실행되면 자동으로 "http://localhost:8000/api/v1/users/start"로 post를 보내서 유저 자동 생성
 # def call_start_api_after_server_ready():

--- a/app/tests/ending/test_ending.py
+++ b/app/tests/ending/test_ending.py
@@ -1,0 +1,96 @@
+from uuid import uuid4
+from datetime import date
+
+from app.models.user import User
+from app.models.animal import Animal
+from app.models.moneyTransaction import MoneyTransaction
+from app.models.attendance import AttendanceLog
+from app.models.birthday import BirthdayReward
+
+
+def test_reset_game_success(client, db_session):
+    # 1) 사용자 생성
+    res = client.post("/api/v1/users/start")
+    assert res.status_code == 201
+    user_id = res.json()["userId"]
+
+    # 2) 동물 이름 등록 (Animals 생성)
+    nickname_payload = {
+        "animals": [
+            {"animalId": 1, "name": "시바"},
+            {"animalId": 2, "name": "병아리"},
+            {"animalId": 3, "name": "오리"},
+        ]
+    }
+    res_nick = client.post(
+        "/api/v1/pets/nickname",
+        json=nickname_payload,
+        headers={"user-id": user_id},
+    )
+    assert res_nick.status_code == 200
+
+    # 3) MoneyTransactions, AttendanceLog, BirthdayReward 생성
+    # 3-1) 거래 하나 생성 (MoneyTransactions 생성)
+    tx_payload = {"amount": 100, "source": "test"}
+    res_tx = client.post(
+        "/api/v1/users/transactions",
+        json=tx_payload,
+        headers={"user-id": user_id},
+    )
+    assert res_tx.status_code == 201
+
+    # 3-2) 출석 로그/생일 보상 더미 데이터 삽입
+    # AttendanceReward가 없을 수도 있으므로 하나 확보
+    from app.models.attendance import AttendanceReward
+
+    reward = db_session.query(AttendanceReward).first()
+    if reward is None:
+        reward = AttendanceReward(rewardAmount=10, rewardType="money")
+        db_session.add(reward)
+        db_session.commit()
+
+    db_session.add(AttendanceLog(date=date.today(), userId=user_id, attendanceRewardId=reward.attendanceRewardId))
+    db_session.add(BirthdayReward(date=date.today(), userId=user_id, animalId=1))
+    db_session.commit()
+
+    # 4) 리셋 호출
+    res_reset = client.post(
+        "/api/v1/endings/reset",
+        headers={"user-id": user_id},
+    )
+    assert res_reset.status_code == 200
+    body = res_reset.json()
+    assert body["status"] == 200
+    assert body["money"] == 0
+    assert body["totalPlayDays"] == 0
+    assert body["totalUsedMoney"] == 0
+    assert isinstance(body.get("animals"), list) and len(body["animals"]) == 3
+    for a in body["animals"]:
+        assert a["name"] is None
+        assert a["current_emotion"] == 50
+        assert a["isRunaway"] is False
+
+    # 5) DB 상태 검증: 유저 및 관련 데이터 삭제 확인
+    assert db_session.query(User).filter(User.userId == user_id).first() is None
+    assert db_session.query(Animal).filter(Animal.userId == user_id).count() == 0
+    assert (
+        db_session.query(MoneyTransaction)
+        .filter(MoneyTransaction.userId == user_id)
+        .count()
+        == 0
+    )
+    assert db_session.query(AttendanceLog).filter(AttendanceLog.userId == user_id).count() == 0
+    assert db_session.query(BirthdayReward).filter(BirthdayReward.userId == user_id).count() == 0
+
+
+def test_reset_game_user_not_found(client):
+    # 존재하지 않는 유저로 호출
+    fake_id = str(uuid4())
+    res = client.post(
+        "/api/v1/endings/reset",
+        headers={"user-id": fake_id},
+    )
+    # 서비스에서 404 CustomException을 던지고 컨트롤러가 그대로 반영
+    assert res.status_code == 404 or res.json().get("status") == 404
+
+


### PR DESCRIPTION
## 어떤 기능인가요?

- 게임 전체 설정 초기화(다시 시작) API(`POST /api/v1/ending/reset`)

##  어떻게 구현하면 좋을까요?

구현 아이디어가 있다면 적어주세요.

##  작업 TODO

- [x] 게임 전체 설정 초기화(다시 시작) API(`POST /api/v1/ending/reset`) 구현
- [x] 게임 전체 설정 초기화(다시 시작) API(`POST /api/v1/ending/reset`) 테스트 코드 추가

## 다른 방법이 있을까요?

이 기능의 다른 해결 방법이나 대체 아이디어가 있다면 알려주세요.

##  추가 정보

closes #36 
