### PR TITLE
[FEAT&TEST] 행동 수행 및 적용 (기분 변화 포함)-AI 모델 기반 기분 변화 예측(api/v1/cares/action) 및 테스트 코드 작성 enhancement New feature or request

### DIFF
--- a/app/api/care/controller.py
+++ b/app/api/care/controller.py
@@ -1,19 +1,45 @@
 from fastapi import APIRouter, Depends, Query, Header
 from sqlalchemy.orm import Session
 from uuid import UUID
-from app.api.care.schema import MLInput, PriceListResponse
-from app.api.care.service import predict_emotion, get_price_list_service
+from app.api.care.schema import PriceListResponse, CareActionRequest, CareActionResponse
+from app.api.care.service import get_price_list_service, predict_and_apply_emotion_change, daily_increment_days_since_care_service
 from app.core.database import get_db
 from app.core.exception import CustomException
 
 router = APIRouter(prefix="/api/v1/cares", tags=["Care"])
 
-@router.post("/action") # 기존 /predict 테스트 api 이름만 변경함. 이후에 작업 다시
-def get_emotion_prediction(input_data: MLInput):
-    predicted_delta = predict_emotion(input_data)
-    return {
-        "predicted_emotion_delta": predicted_delta
-    }
+@router.post("/action", response_model=CareActionResponse)
+def perform_care_action(
+    request: CareActionRequest,
+    db: Session = Depends(get_db),
+    user_id: UUID = Header(..., alias="user-id")
+):
+    # CareLogs 시스템에 따른 케어 행동 수행 API
+    try:
+        result = predict_and_apply_emotion_change(
+            db, 
+            user_id, 
+            request.animal_id, 
+            request.action_id
+        )
+        return result
+    except CustomException as e:
+        raise e
+    except Exception as e:
+        raise CustomException(message="서버 내부 오류가 발생했습니다.", status=500)
+
+@router.post("/batch/daily-increment")
+def daily_increment_days_since_care(
+    db: Session = Depends(get_db)
+):
+    # 자정 배치용 - 모든 동물의 마지막 케어 이후 경과일 +1 증가
+    try:
+        result = daily_increment_days_since_care_service(db)
+        return result
+    except CustomException as e:
+        raise e
+    except Exception as e:
+        raise CustomException(message="서버 내부 오류가 발생했습니다.", status=500)
 
 @router.get("/pricelist", response_model=PriceListResponse)
 def get_price_list(

--- a/app/api/care/repository.py
+++ b/app/api/care/repository.py
@@ -1,15 +1,12 @@
 from sqlalchemy.orm import Session
-from sqlalchemy import and_
-from typing import List, Optional
-from uuid import UUID
+from sqlalchemy import func, and_, desc
 from app.models.animal import Animal
 from app.models.action import Action
 from app.models.category import Category
-
-def get_animal_by_id(db: Session, animal_id: int, user_id: UUID) -> Optional[Animal]:
-    return db.query(Animal).filter(
-        and_(Animal.animalId == animal_id, Animal.userId == user_id)
-    ).first()
+from app.models.action_log import ActionLog
+from uuid import UUID
+from typing import List, Optional
+from datetime import datetime, timedelta
 
 def get_actions_by_category_and_evolution(db: Session, category_name: str, evolution_stage: int) -> List[Action]:
     return db.query(Action).join(Category).filter(
@@ -18,3 +15,158 @@ def get_actions_by_category_and_evolution(db: Session, category_name: str, evolu
 
 def get_category_by_name(db: Session, category_name: str) -> Optional[Category]:
     return db.query(Category).filter(Category.name == category_name).first()
+
+def get_action_by_id(db: Session, action_id: int) -> Optional[Action]:
+    return db.query(Action).filter(Action.actionId == action_id).first()
+
+def calculate_recent_action_count(db: Session, user_id: UUID, animal_id: int, action_ml_name: str) -> int:
+    # 오늘(자정부터 현재까지) 해당 카테고리의 모든 액션 수행 횟수
+    try:
+        today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        
+        # action_ml_name에서 카테고리만 추출
+        if action_ml_name.startswith('feed'):
+            category = 'feed'
+        elif action_ml_name.startswith('play'):
+            category = 'play'
+        elif action_ml_name.startswith('gift'):
+            category = 'gift'
+        else:
+            return 0
+        
+        # 카테고리 ID 조회
+        category_obj = db.query(Category).filter(Category.name == category).first()
+        if not category_obj:
+            return 0
+        
+        # 카테고리별로 모든 레벨의 액션 수 카운트 (actionLevel 조건 제거)
+        count = db.query(func.count(ActionLog.logId)).join(Action).filter(
+            and_(
+                ActionLog.userId == user_id,
+                ActionLog.animalId == animal_id,
+                Action.categoryId == category_obj.categoryId,
+                ActionLog.performedAt >= today_start
+            )
+        ).scalar()
+        
+        return count or 0
+    except Exception as e:
+        print(f"Error calculating recent action count: {str(e)}")
+        return 0
+
+def calculate_days_since_last_care(db: Session, animal_id: int, user_id: UUID) -> int:
+    # 마지막 케어 이후 경과 일수
+    try:
+        last_care = db.query(func.max(ActionLog.performedAt)).filter(
+            and_(
+                ActionLog.animalId == animal_id,
+                ActionLog.userId == user_id
+            )
+        ).scalar()
+        
+        if last_care and last_care is not None:
+            return (datetime.now() - last_care).days
+        return 0
+    except Exception as e:
+        print(f"Error calculating days since last care: {str(e)}")
+        return 0
+
+def update_animal_emotion(db: Session, animal_id: int, user_id: UUID, new_emotion: float) -> None:
+    # 동물의 감정 상태 업데이트
+    update_data = {"currentEmotion": new_emotion}
+    
+    # 감정이 0 이하가 되면 가출 상태로 변경
+    if new_emotion <= 0:
+        update_data["isRunaway"] = True
+    
+    db.query(Animal).filter(
+        and_(Animal.animalId == animal_id, Animal.userId == user_id)
+    ).update(update_data)
+
+def get_all_user_animals(db: Session, user_id: UUID) -> List[Animal]:
+    # 사용자의 모든 동물 조회
+    return db.query(Animal).filter(Animal.userId == user_id).all()
+
+def update_user_pattern_bias(db: Session, user_id: UUID, target_animal_id: int, transfer_rate: float = 0.3):
+    # 편애도 업데이트 로직 (전이율 기반)
+    animals = get_all_user_animals(db, user_id)
+    
+    if not animals:
+        return
+    
+    # 현재 편애도 값들을 가져오기
+    animal_biases = {}
+    target_animal = None
+    other_animals = []
+    
+    for animal in animals:
+        current_bias = float(animal.userPatternBias)
+        animal_biases[animal.animalId] = current_bias
+        
+        if animal.animalId == target_animal_id:
+            target_animal = animal
+        else:
+            other_animals.append(animal)
+    
+    if not target_animal:
+        return
+    
+    # 편애도 계산
+    target_current_bias = animal_biases[target_animal_id]
+    transfer_amount_per_animal = 0
+    
+    # 다른 동물들로부터 전이받을 양 계산
+    for other_animal in other_animals:
+        other_bias = animal_biases[other_animal.animalId]
+        transfer_from_this = other_bias * transfer_rate
+        transfer_amount_per_animal += transfer_from_this
+    
+    # 새로운 편애도 계산 (소수점 4자리로 반올림)
+    new_target_bias = round(target_current_bias + transfer_amount_per_animal, 4)
+    
+    # 타겟 동물 업데이트
+    db.query(Animal).filter(
+        and_(Animal.userId == user_id, Animal.animalId == target_animal_id)
+    ).update({"userPatternBias": new_target_bias})
+    
+    # 다른 동물들 업데이트 (각자 전이율만큼 감소, 소수점 4자리로 반올림)
+    for other_animal in other_animals:
+        current_bias = animal_biases[other_animal.animalId]
+        new_bias = round(current_bias * (1 - transfer_rate), 4)
+        
+        db.query(Animal).filter(
+            and_(Animal.userId == user_id, Animal.animalId == other_animal.animalId)
+        ).update({"userPatternBias": new_bias})
+
+def reset_animal_days_since_care(db: Session, user_id: UUID, animal_id: int) -> None:
+    # 특정 동물의 마지막 케어 이후 경과일을 0으로 리셋
+    db.query(Animal).filter(
+        and_(Animal.userId == user_id, Animal.animalId == animal_id)
+    ).update({"daySinceLastCare": 0})
+
+def increment_all_animals_days_since_care(db: Session) -> None:
+    # 모든 동물의 마지막 케어 이후 경과일을 1씩 증가 (자정 배치용)
+    db.query(Animal).update(
+        {"daySinceLastCare": Animal.daySinceLastCare + 1}
+    )
+    db.commit()
+
+def log_action_result(db: Session, user_id: UUID, animal_id: int, action_id: int, 
+                     emotion_before: float, emotion_after: float, predicted_delta: float,
+                     user_pattern_bias: float, days_since_last_care: int) -> None:
+    # 행동 결과를 로그에 기록
+    actual_delta = emotion_after - emotion_before
+    
+    action_log = ActionLog(
+        userId=user_id,
+        animalId=animal_id,
+        actionId=action_id,
+        emotionBefore=emotion_before,
+        emotionAfter=emotion_after,
+        predictedDelta=predicted_delta,
+        actualDelta=actual_delta,
+        userPatternBias=user_pattern_bias,
+        daysSinceLastCare=days_since_last_care
+    )
+    
+    db.add(action_log)

--- a/app/api/care/schema.py
+++ b/app/api/care/schema.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import Dict
+from uuid import UUID
 
 class MLInput(BaseModel):
     current_emotion: int
@@ -18,6 +19,18 @@ class MLInput(BaseModel):
     action_gift1: int
     action_gift2: int
     action_gift3: int
+
+class CareActionRequest(BaseModel):
+    animal_id: int
+    action_id: int
+
+class CareActionResponse(BaseModel):
+    predictedDelta: float
+    newEmotion: float
+    previousEmotion: float
+    actionPerformed: str
+    message: str
+    status: int
 
 class PriceListResponse(BaseModel):
     animalId: int

--- a/app/api/care/service.py
+++ b/app/api/care/service.py
@@ -1,14 +1,22 @@
 import os
 import joblib
 import pandas as pd
+import math
 from dotenv import load_dotenv
 from sqlalchemy.orm import Session
 from uuid import UUID
 from typing import Dict, Optional
 
-from app.api.care.schema import MLInput, PriceListResponse
-from app.api.care.repository import get_animal_by_id, get_actions_by_category_and_evolution, get_category_by_name
-from app.api.pet.service import get_pet_info_service
+from app.api.care.schema import MLInput, PriceListResponse, CareActionResponse
+from app.api.care.repository import (
+    get_actions_by_category_and_evolution, get_category_by_name,
+    get_action_by_id, calculate_recent_action_count, calculate_days_since_last_care,
+    update_animal_emotion, log_action_result, update_user_pattern_bias,
+    reset_animal_days_since_care, increment_all_animals_days_since_care
+)
+from app.api.pet.repository import get_animal_by_user_and_id
+from app.models.category import Category
+from app.api.user.service import process_transaction
 from app.core.exception import CustomException
 
 # .env 파일 로드
@@ -20,18 +28,144 @@ model_path = os.getenv("MODEL_PATH", "./ML/emotion_model.pkl")
 # 모델 불러오기
 model = joblib.load(model_path)
 
-# ML 모델로부터 감정 변화량을 받아오는 함수 
-def predict_emotion(input_data: MLInput) -> float:
-    # 16개의 모든 필드를 그대로 받아서 예측에 사용
-    data = input_data.dict()
 
-    # DataFrame으로 변환
+def predict_and_apply_emotion_change(db: Session, user_id: UUID, animal_id: int, action_id: int) -> CareActionResponse:
+    # 감정 변화 예측 및 적용
+    
+    # 1. 기본 데이터 조회
+    animal = get_animal_by_user_and_id(db, user_id, animal_id)
+    if not animal:
+        raise CustomException(message="존재하지 않는 동물입니다.", status=404)
+    
+    action = get_action_by_id(db, action_id)
+    if not action:
+        raise CustomException(message="존재하지 않는 행동입니다.", status=404)
+    
+    # 2. 비즈니스 규칙 검사
+    validate_action_requirements(animal, action, user_id)
+    
+    if animal.currentEmotion >= 100:
+        raise CustomException(message="이미 감정이 최대치입니다.", status=400)
+    
+    # 3. 비용 확인 및 차감
+    action_cost = action.price
+    if action_cost > 0:
+        try:
+            process_transaction(db, user_id, -action_cost, "care", commit=False)
+        except CustomException as e:
+            raise e
+    
+    # 4. 행동 전 상태 정보 저장 (로그용)
+    previous_emotion = float(animal.currentEmotion)
+    previous_bias = float(animal.userPatternBias)
+    days_since_care = calculate_days_since_last_care(db, animal_id, user_id)
+    
+    # 5. ML 모델 입력 구성
+    ml_input = create_ml_input_from_db(db, animal, action, user_id)
+    
+    # 6. ML 모델 예측
+    data = ml_input.dict()
     df_input = pd.DataFrame([data])
+    predicted_delta = float(model.predict(df_input, validate_features=False)[0])
+    
+    # 7. 새로운 감정값 계산 (0-100 범위 제한)
+    raw_new_emotion = previous_emotion + predicted_delta
+    
+    # 양수는 올림, 음수는 내림 처리
+    if raw_new_emotion >= 0:
+        new_emotion = math.ceil(raw_new_emotion)
+    else:
+        new_emotion = math.floor(raw_new_emotion)
+    
+    # 0-100 범위 제한
+    new_emotion = max(0, min(100, new_emotion))
+    
+    # 8. 데이터베이스 업데이트 (트랜잭션으로 모든 변경사항 한번에 커밋)
+    try:
+        # 감정 상태 업데이트
+        update_animal_emotion(db, animal_id, user_id, new_emotion)
+        
+        # 편애도 업데이트 (전이율 0.3 적용)
+        update_user_pattern_bias(db, user_id, animal_id, transfer_rate=0.3)
+        
+        # 마지막 케어 이후 경과일 리셋 (action 수행 시 0으로)
+        reset_animal_days_since_care(db, user_id, animal_id)
+        
+        # 행동 로그 기록 (행동 전 편애도와 경과 일수 포함)
+        log_action_result(db, user_id, animal_id, action_id, previous_emotion, 
+                         new_emotion, predicted_delta, previous_bias, days_since_care)
+        
+        db.commit()  # 모든 변경사항 (비용 차감, 감정 업데이트, 편애도 업데이트, 경과일 리셋, 로그 기록) 커밋
+    except Exception as e:
+        db.rollback()
+        print(f"Database update error: {str(e)}")  # 디버깅용 로그
+        raise CustomException(message=f"데이터베이스 업데이트 중 오류가 발생했습니다: {str(e)}", status=500)
+    
+    # 9. 응답 구성
+    return CareActionResponse(
+        predictedDelta=round(predicted_delta, 2),
+        newEmotion=new_emotion,
+        previousEmotion=previous_emotion,
+        actionPerformed=action.name,
+        message="감정 변화 예측 완료 및 반영됨",
+        status=200
+    )
 
-    # 컬럼 순서 맞추기 필요 없음 -> validate_features=False 옵션 추가!
-    prediction = model.predict(df_input, validate_features=False)[0]
+def validate_action_requirements(animal, action, user_id: UUID) -> None:
+    # 유효성 검사
+    # 동물 소유권 확인
+    if animal.userId != user_id:
+        raise CustomException(message="해당 동물에 대한 권한이 없습니다.", status=403)
+    
+    # 가출 상태 확인
+    if animal.isRunaway:
+        raise CustomException(message="가출 중인 동물은 행동을 수행할 수 없습니다.", status=400)
+    
+    # 진화 단계 확인
+    if animal.evolutionStage != action.evolutionStage:
+        raise CustomException(message="현재 진화 단계와 맞지 않는 행동입니다.", status=400)
 
-    return float(prediction)
+def create_ml_input_from_db(db: Session, animal, action, user_id: UUID) -> MLInput:
+    # ML 입력 데이터 구성
+    
+    # 동물 타입 매핑 (animalId를 타입으로 변환)
+    animal_type_mapping = {1: 'shiba', 2: 'duck', 3: 'chick'}
+    animal_type = animal_type_mapping.get(animal.animalId, 'chick')
+    
+    # 액션명 매핑 (category와 level을 ML 모델 형식으로)
+    category_obj = db.query(Category).filter(Category.categoryId == action.categoryId).first()
+    category_name = category_obj.name if category_obj else 'feed'
+    action_ml_name = f"{category_name}{action.actionLevel}"
+    
+    # 계산된 값들
+    recent_action_count = calculate_recent_action_count(db, user_id, animal.animalId, action_ml_name)
+    days_since_care = calculate_days_since_last_care(db, animal.animalId, user_id)
+    
+    # ML 모델 입력 구성
+    ml_input_dict = {
+        'current_emotion': int(float(animal.currentEmotion)),
+        'action_count': recent_action_count,
+        'user_pattern_bias': float(animal.userPatternBias),
+        'days_since_last_care': days_since_care,
+        
+        # 동물 타입 OneHot 인코딩
+        'animal_type_chick': 1 if animal_type == 'chick' else 0,
+        'animal_type_duck': 1 if animal_type == 'duck' else 0,
+        'animal_type_shiba': 1 if animal_type == 'shiba' else 0,
+        
+        # 액션 OneHot 인코딩 (선택된 액션만 1, 나머지는 0)
+        'action_feed1': 1 if action_ml_name == 'feed1' else 0,
+        'action_feed2': 1 if action_ml_name == 'feed2' else 0,
+        'action_feed3': 1 if action_ml_name == 'feed3' else 0,
+        'action_play1': 1 if action_ml_name == 'play1' else 0,
+        'action_play2': 1 if action_ml_name == 'play2' else 0,
+        'action_play3': 1 if action_ml_name == 'play3' else 0,
+        'action_gift1': 1 if action_ml_name == 'gift1' else 0,
+        'action_gift2': 1 if action_ml_name == 'gift2' else 0,
+        'action_gift3': 1 if action_ml_name == 'gift3' else 0,
+    }
+    
+    return MLInput(**ml_input_dict)
 
 # 가격 정보 조회 서비스
 def get_price_list_service(db: Session, category: str, animal_id: int, user_id: UUID) -> PriceListResponse:
@@ -43,16 +177,16 @@ def get_price_list_service(db: Session, category: str, animal_id: int, user_id: 
             status=400
         )
     
-    # 동물 상태 정보 조회 (pet service 사용)
-    pet_info = get_pet_info_service(db, user_id, animal_id)
-    if not pet_info:
+    # 동물 상태 정보 조회 (pet repository 직접 사용)
+    animal = get_animal_by_user_and_id(db, user_id, animal_id)
+    if not animal:
         raise CustomException(
             message="존재하지 않는 동물 ID입니다.",
             status=404
         )
     
-    # pet service에서 계산된 진화 단계 사용
-    evolution_stage = pet_info.evolutionStage
+    # 동물의 진화 단계 사용
+    evolution_stage = animal.evolutionStage
 
     print(evolution_stage)
     
@@ -78,3 +212,15 @@ def get_price_list_service(db: Session, category: str, animal_id: int, user_id: 
         message=message,
         status=200
     )
+
+def daily_increment_days_since_care_service(db: Session) -> dict:
+    # 자정 배치용 - 모든 동물의 마지막 케어 이후 경과일 +1 증가
+    try:
+        increment_all_animals_days_since_care(db)
+        return {
+            "message": "모든 동물의 마지막 케어 이후 경과일이 1일씩 증가되었습니다.",
+            "status": 200
+        }
+    except Exception as e:
+        db.rollback()
+        raise CustomException(message="경과일 업데이트 중 오류가 발생했습니다.", status=500)

--- a/app/api/pet/service.py
+++ b/app/api/pet/service.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from datetime import date
 
 from app.api.pet.schema import AnimalInfoResponse
-from app.api.pet.repository import create_animal, get_animal_by_user_and_id, reset_emotion_and_deduct_money, update_animal_runaway_status, update_animal_evolution_stage
+from app.api.pet.repository import create_animal, get_animal_by_user_and_id, reset_emotion_and_deduct_money, update_animal_runaway_status
 from app.core.exception import CustomException
 
 # 동물 이름 새로 지어주면서 만들기(/pets/nickname)
@@ -45,23 +45,13 @@ def get_pet_info_service(db: Session, user_id: UUID, animal_id: int) -> AnimalIn
     if animal is None:
         return None
 
-    emotion = animal.currentEmotion
-    if emotion >= 90:
-        evolutionStage = 3
-    elif emotion >= 70:
-        evolutionStage = 2
-    else:
-        evolutionStage = 1
-
-    # 계산된 진화 단계가 데이터베이스의 기존 진화 단계와 다르면 업데이트
-    if animal.evolutionStage != evolutionStage:
-        animal = update_animal_evolution_stage(db, user_id, animal_id, evolutionStage)
+    evolutionStage = animal.evolutionStage
 
     return AnimalInfoResponse(
         animalId=animal.animalId,
         name=animal.name,
         userPatternBias=animal.userPatternBias,
-        evolutionStage=evolutionStage,
+        evolutionStage=animal.evolutionStage,
         currentEmotion=animal.currentEmotion,
         isRunaway=animal.isRunaway,
         status=200

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,7 @@
 from .user import User
 from .animal import Animal
 from .attendance import AttendanceReward, AttendanceLog
+from .action import Action
+from .category import Category
+from .action_log import ActionLog
 # __init__.py로 인해 models 외부(create_table.py)에서 from models.animal.animalModel import Animal 가 아닌 from models import Animal와 같이 접근 가능

--- a/app/models/action_log.py
+++ b/app/models/action_log.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Integer, String, Numeric, DateTime, ForeignKey, func
+from sqlalchemy.dialects.postgresql import UUID
+from app.core.database import Base
+
+class ActionLog(Base):
+    __tablename__ = "CareLogs"
+
+    logId = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    userId = Column(UUID(as_uuid=True), ForeignKey("Users.userId"), nullable=False)
+    animalId = Column(Integer, nullable=False)
+    actionId = Column(Integer, ForeignKey("Actions.actionId"), nullable=False)
+    emotionBefore = Column(Numeric(5, 2), nullable=False)
+    emotionAfter = Column(Numeric(5, 2), nullable=False)
+    predictedDelta = Column(Numeric(6, 2), nullable=False)
+    actualDelta = Column(Numeric(6, 2), nullable=False)
+    userPatternBias = Column(Numeric(5, 4), nullable=False)
+    daysSinceLastCare = Column(Integer, nullable=False)
+    performedAt = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/tests/care/test_care.py
+++ b/app/tests/care/test_care.py
@@ -251,3 +251,472 @@ def test_get_price_list_missing_query_parameters(client, db_session):
         headers={"user-id": str(user_id)}
     )
     assert response.status_code == 422
+
+# /action API 테스트 코드
+# 테스트 9: 정상적인 케어 액션 수행 성공
+def test_care_action_success(client, db_session, monkeypatch):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+    user_data = user_response.json()
+    user_id = user_data["userId"]
+
+    # 테스트용 동물 생성
+    animal_id = random.randint(1, 3)
+    animal = Animal(
+        animalId=animal_id,
+        userId=user_id,
+        name="테스트동물",
+        isRunaway=False,
+        evolutionStage=1,
+        currentEmotion=50.0,
+        birthday=date.today(),
+        userPatternBias=0.33,
+        daySinceLastCare=0
+    )
+    db_session.add(animal)
+    db_session.commit()
+
+    # 유저 잔액 설정 (10000 골드)
+    user = db_session.query(User).filter(User.userId == user_id).first()
+    user.money = 10000
+    db_session.commit()
+
+    # Mock ML 모델 예측 결과
+    def mock_predict(self, data, validate_features=False):
+        return [15.5]  # 감정 증가량 예측 값
+    
+    # joblib.load를 mock하여 가짜 모델 반환
+    def mock_load(path):
+        class MockModel:
+            def predict(self, data, validate_features=False):
+                return [15.5]
+        return MockModel()
+    
+    monkeypatch.setattr("joblib.load", mock_load)
+
+    # 케어 액션 요청 (actionId=1은 feed1이라고 가정)
+    action_request = {
+        "animal_id": animal_id,
+        "action_id": 1
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user_id)}
+    )
+
+    # 응답 검증
+    assert response.status_code == 200
+    data = response.json()
+    assert "predictedDelta" in data
+    assert "newEmotion" in data
+    assert "previousEmotion" in data
+    assert "actionPerformed" in data
+    assert data["message"] == "감정 변화 예측 완료 및 반영됨"
+    assert data["status"] == 200
+    assert data["previousEmotion"] == 50.0
+
+# 테스트 10: 존재하지 않는 동물 ID로 케어 액션 수행 실패
+def test_care_action_invalid_animal(client, db_session, monkeypatch):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+    user_data = user_response.json()
+    user_id = user_data["userId"]
+
+    # Mock ML 모델
+    def mock_load(path):
+        class MockModel:
+            def predict(self, data, validate_features=False):
+                return [15.5]
+        return MockModel()
+    
+    monkeypatch.setattr("joblib.load", mock_load)
+
+    # 존재하지 않는 동물 ID로 요청
+    action_request = {
+        "animal_id": 999,
+        "action_id": 1
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user_id)}
+    )
+
+    # 에러 응답 검증
+    assert response.status_code == 404
+    data = response.json()
+    assert data["message"] == "존재하지 않는 동물입니다."
+    assert data["status"] == 404
+
+# 테스트 11: 존재하지 않는 액션 ID로 케어 액션 수행 실패
+def test_care_action_invalid_action(client, db_session, monkeypatch):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+    user_data = user_response.json()
+    user_id = user_data["userId"]
+
+    # 테스트용 동물 생성
+    animal_id = random.randint(1, 3)
+    animal = Animal(
+        animalId=animal_id,
+        userId=user_id,
+        name="테스트동물",
+        isRunaway=False,
+        evolutionStage=1,
+        currentEmotion=50.0,
+        birthday=date.today(),
+        userPatternBias=0.33,
+        daySinceLastCare=0
+    )
+    db_session.add(animal)
+    db_session.commit()
+
+    # Mock ML 모델
+    def mock_load(path):
+        class MockModel:
+            def predict(self, data, validate_features=False):
+                return [15.5]
+        return MockModel()
+    
+    monkeypatch.setattr("joblib.load", mock_load)
+
+    # 존재하지 않는 액션 ID로 요청
+    action_request = {
+        "animal_id": animal_id,
+        "action_id": 999
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user_id)}
+    )
+
+    # 에러 응답 검증
+    assert response.status_code == 404
+    data = response.json()
+    assert data["message"] == "존재하지 않는 행동입니다."
+    assert data["status"] == 404
+
+# 테스트 12: 다른 사용자 소유의 동물에 케어 액션 수행 실패
+def test_care_action_unauthorized_animal(client, db_session, monkeypatch):
+    # 첫 번째 유저 생성
+    user_response1 = client.post("/api/v1/users/start")
+    user1_id = user_response1.json()["userId"]
+    
+    # 두 번째 유저 생성
+    user_response2 = client.post("/api/v1/users/start")
+    user2_id = user_response2.json()["userId"]
+
+    # 첫 번째 유저 소유의 동물 생성
+    animal_id = random.randint(1, 3)
+    animal = Animal(
+        animalId=animal_id,
+        userId=user1_id,
+        name="테스트동물",
+        isRunaway=False,
+        evolutionStage=1,
+        currentEmotion=50.0,
+        birthday=date.today(),
+        userPatternBias=0.33,
+        daySinceLastCare=0
+    )
+    db_session.add(animal)
+    db_session.commit()
+
+    # Mock ML 모델
+    def mock_load(path):
+        class MockModel:
+            def predict(self, data, validate_features=False):
+                return [15.5]
+        return MockModel()
+    
+    monkeypatch.setattr("joblib.load", mock_load)
+
+    # 두 번째 유저가 첫 번째 유저의 동물에 액션 시도
+    action_request = {
+        "animal_id": animal_id,
+        "action_id": 1
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user2_id)}
+    )
+
+    # 권한 없음 에러 응답 검증
+    assert response.status_code == 404  # animal not found for this user
+    data = response.json()
+    assert data["message"] == "존재하지 않는 동물입니다."
+    assert data["status"] == 404
+
+# 테스트 13: 가출 중인 동물에 케어 액션 수행 실패
+def test_care_action_runaway_animal(client, db_session, monkeypatch):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+    user_data = user_response.json()
+    user_id = user_data["userId"]
+
+    # 가출 중인 테스트용 동물 생성
+    animal_id = random.randint(1, 3)
+    animal = Animal(
+        animalId=animal_id,
+        userId=user_id,
+        name="테스트동물",
+        isRunaway=True,  # 가출 상태
+        evolutionStage=1,
+        currentEmotion=50.0,
+        birthday=date.today(),
+        userPatternBias=0.33,
+        daySinceLastCare=0
+    )
+    db_session.add(animal)
+    db_session.commit()
+
+    # Mock ML 모델
+    def mock_load(path):
+        class MockModel:
+            def predict(self, data, validate_features=False):
+                return [15.5]
+        return MockModel()
+    
+    monkeypatch.setattr("joblib.load", mock_load)
+
+    # 케어 액션 요청
+    action_request = {
+        "animal_id": animal_id,
+        "action_id": 1
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user_id)}
+    )
+
+    # 에러 응답 검증
+    assert response.status_code == 400
+    data = response.json()
+    assert data["message"] == "가출 중인 동물은 행동을 수행할 수 없습니다."
+    assert data["status"] == 400
+
+# 테스트 14: 감정이 이미 최대치(100)인 동물에 케어 액션 수행 실패
+def test_care_action_max_emotion(client, db_session, monkeypatch):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+    user_data = user_response.json()
+    user_id = user_data["userId"]
+
+    # 감정 최대치인 테스트용 동물 생성
+    animal_id = random.randint(1, 3)
+    animal = Animal(
+        animalId=animal_id,
+        userId=user_id,
+        name="테스트동물",
+        isRunaway=False,
+        evolutionStage=1,
+        currentEmotion=100.0,  # 감정 최대치
+        birthday=date.today(),
+        userPatternBias=0.33,
+        daySinceLastCare=0
+    )
+    db_session.add(animal)
+    db_session.commit()
+
+    # Mock ML 모델
+    def mock_load(path):
+        class MockModel:
+            def predict(self, data, validate_features=False):
+                return [15.5]
+        return MockModel()
+    
+    monkeypatch.setattr("joblib.load", mock_load)
+
+    # 케어 액션 요청
+    action_request = {
+        "animal_id": animal_id,
+        "action_id": 1
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user_id)}
+    )
+
+    # 에러 응답 검증
+    assert response.status_code == 400
+    data = response.json()
+    assert data["message"] == "이미 감정이 최대치입니다."
+    assert data["status"] == 400
+
+# 테스트 15: 잔액 부족으로 케어 액션 수행 실패
+def test_care_action_insufficient_funds(client, db_session, monkeypatch):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+    user_data = user_response.json()
+    user_id = user_data["userId"]
+
+    # 테스트용 동물 생성
+    animal_id = random.randint(1, 3)
+    animal = Animal(
+        animalId=animal_id,
+        userId=user_id,
+        name="테스트동물",
+        isRunaway=False,
+        evolutionStage=1,
+        currentEmotion=50.0,
+        birthday=date.today(),
+        userPatternBias=0.33,
+        daySinceLastCare=0
+    )
+    db_session.add(animal)
+    db_session.commit()
+
+    # 유저 잔액을 매우 적게 설정
+    user = db_session.query(User).filter(User.userId == user_id).first()
+    user.money = 1  # 매우 적은 잔액
+    db_session.commit()
+
+    # Mock ML 모델
+    def mock_load(path):
+        class MockModel:
+            def predict(self, data, validate_features=False):
+                return [15.5]
+        return MockModel()
+    
+    monkeypatch.setattr("joblib.load", mock_load)
+
+    # 케어 액션 요청
+    action_request = {
+        "animal_id": animal_id,
+        "action_id": 1  # 이 액션이 1골드보다 비쌀 것으로 가정
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user_id)}
+    )
+
+    # 잔액 부족 에러 응답 검증 (user service에서 발생)
+    assert response.status_code == 400
+    data = response.json()
+    assert "잔액이 부족합니다" in data["message"]
+    assert data["status"] == 400
+
+# 테스트 16: 필수 헤더(user-id) 누락 시 에러 처리
+def test_care_action_missing_user_id_header(client, db_session):
+    # 케어 액션 요청 (user-id 헤더 없이)
+    action_request = {
+        "animal_id": 1,
+        "action_id": 1
+    }
+    
+    response = client.post("/api/v1/cares/action", json=action_request)
+
+    # 에러 응답 검증
+    assert response.status_code == 422
+
+# 테스트 17: 잘못된 요청 본문으로 케어 액션 수행 실패
+def test_care_action_invalid_request_body(client, db_session):
+    user_response = client.post("/api/v1/users/start")
+    user_id = user_response.json()["userId"]
+
+    # animal_id 누락
+    action_request = {
+        "action_id": 1
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user_id)}
+    )
+    assert response.status_code == 422
+
+    # action_id 누락
+    action_request = {
+        "animal_id": 1
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user_id)}
+    )
+    assert response.status_code == 422
+
+    # 빈 요청 본문
+    response = client.post(
+        "/api/v1/cares/action",
+        json={},
+        headers={"user-id": str(user_id)}
+    )
+    assert response.status_code == 422
+
+# 테스트 18: 감정값 경계 테스트 - 음수 감정값 처리
+def test_care_action_negative_emotion_result(client, db_session, monkeypatch):
+    # 먼저 유저 생성 API 호출
+    user_response = client.post("/api/v1/users/start")
+    assert user_response.status_code == 201
+    user_data = user_response.json()
+    user_id = user_data["userId"]
+
+    # 매우 낮은 감정의 테스트용 동물 생성
+    animal_id = random.randint(1, 3)
+    animal = Animal(
+        animalId=animal_id,
+        userId=user_id,
+        name="테스트동물",
+        isRunaway=False,
+        evolutionStage=1,
+        currentEmotion=5.0,  # 낮은 감정
+        birthday=date.today(),
+        userPatternBias=0.33,
+        daySinceLastCare=0
+    )
+    db_session.add(animal)
+    db_session.commit()
+
+    # 유저 잔액 설정
+    user = db_session.query(User).filter(User.userId == user_id).first()
+    user.money = 10000
+    db_session.commit()
+
+    # Mock ML 모델이 매우 큰 음수값 반환
+    def mock_load(path):
+        class MockModel:
+            def predict(self, data, validate_features=False):
+                return [-20.0]  # 결과적으로 음수 감정이 될 것
+        return MockModel()
+    
+    monkeypatch.setattr("joblib.load", mock_load)
+
+    # 케어 액션 요청
+    action_request = {
+        "animal_id": animal_id,
+        "action_id": 1
+    }
+    
+    response = client.post(
+        "/api/v1/cares/action",
+        json=action_request,
+        headers={"user-id": str(user_id)}
+    )
+
+    # 응답 검증 - 감정값이 0으로 제한되어야 함
+    assert response.status_code == 200
+    data = response.json()
+    assert data["newEmotion"] >= 0  # 감정은 0 이상이어야 함
+    assert data["previousEmotion"] == 5.0

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -12,11 +12,77 @@ from app.core.config import KST
 # Import all models to ensure they are registered with Base
 from app.models.birthday import BirthdayReward
 from app.models.animal import Animal
+from app.models.category import Category
+from app.models.action import Action
+from app.models.attendance import AttendanceReward
 
-# Create tables before running tests
+# Create tables and insert initial data before running tests
 @pytest.fixture(scope="session", autouse=True)
 def create_tables():
     Base.metadata.create_all(bind=engine)
+    
+    # Insert initial test data if not exists
+    session = SessionLocal()
+    try:
+        # Categories 초기 데이터
+        if session.query(Category).count() == 0:
+            categories = [
+                Category(name='play'),
+                Category(name='feed'), 
+                Category(name='gift'),
+            ]
+            session.add_all(categories)
+            session.commit()
+            
+        # Actions 초기 데이터
+        if session.query(Action).count() == 0:
+            play_category = session.query(Category).filter(Category.name == 'play').first()
+            feed_category = session.query(Category).filter(Category.name == 'feed').first()
+            gift_category = session.query(Category).filter(Category.name == 'gift').first()
+            
+            actions = [
+                # Play actions
+                Action(name='산책 가기', price=30, actionLevel=1, evolutionStage=1, categoryId=play_category.categoryId),
+                Action(name='공 놀이', price=40, actionLevel=2, evolutionStage=1, categoryId=play_category.categoryId),
+                Action(name='애견 카페 가기', price=50, actionLevel=3, evolutionStage=1, categoryId=play_category.categoryId),
+                Action(name='산책 가기', price=50, actionLevel=1, evolutionStage=2, categoryId=play_category.categoryId),
+                Action(name='공 놀이', price=60, actionLevel=2, evolutionStage=2, categoryId=play_category.categoryId),
+                Action(name='애견 카페 가기', price=70, actionLevel=3, evolutionStage=2, categoryId=play_category.categoryId),
+                Action(name='산책 가기', price=80, actionLevel=1, evolutionStage=3, categoryId=play_category.categoryId),
+                Action(name='공 놀이', price=90, actionLevel=2, evolutionStage=3, categoryId=play_category.categoryId),
+                Action(name='애견 카페 가기', price=100, actionLevel=3, evolutionStage=3, categoryId=play_category.categoryId),
+                
+                # Feed actions
+                Action(name='시장 사료', price=30, actionLevel=1, evolutionStage=1, categoryId=feed_category.categoryId),
+                Action(name='마트 사료', price=40, actionLevel=2, evolutionStage=1, categoryId=feed_category.categoryId),
+                Action(name='유기농 사료', price=50, actionLevel=3, evolutionStage=1, categoryId=feed_category.categoryId),
+                Action(name='시장 사료', price=50, actionLevel=1, evolutionStage=2, categoryId=feed_category.categoryId),
+                Action(name='마트 사료', price=60, actionLevel=2, evolutionStage=2, categoryId=feed_category.categoryId),
+                Action(name='유기농 사료', price=70, actionLevel=3, evolutionStage=2, categoryId=feed_category.categoryId),
+                Action(name='시장 사료', price=80, actionLevel=1, evolutionStage=3, categoryId=feed_category.categoryId),
+                Action(name='마트 사료', price=90, actionLevel=2, evolutionStage=3, categoryId=feed_category.categoryId),
+                Action(name='유기농 사료', price=100, actionLevel=3, evolutionStage=3, categoryId=feed_category.categoryId),
+                
+                # Gift actions
+                Action(name='장난감 사주기', price=30, actionLevel=1, evolutionStage=1, categoryId=gift_category.categoryId),
+                Action(name='예쁜 옷 사주기', price=40, actionLevel=2, evolutionStage=1, categoryId=gift_category.categoryId),
+                Action(name='유모차 사주기', price=50, actionLevel=3, evolutionStage=1, categoryId=gift_category.categoryId),
+                Action(name='장난감 사주기', price=50, actionLevel=1, evolutionStage=2, categoryId=gift_category.categoryId),
+                Action(name='예쁜 옷 사주기', price=60, actionLevel=2, evolutionStage=2, categoryId=gift_category.categoryId),
+                Action(name='유모차 사주기', price=70, actionLevel=3, evolutionStage=2, categoryId=gift_category.categoryId),
+                Action(name='장난감 사주기', price=80, actionLevel=1, evolutionStage=3, categoryId=gift_category.categoryId),
+                Action(name='예쁜 옷 사주기', price=90, actionLevel=2, evolutionStage=3, categoryId=gift_category.categoryId),
+                Action(name='유모차 사주기', price=100, actionLevel=3, evolutionStage=3, categoryId=gift_category.categoryId),
+            ]
+            session.add_all(actions)
+            session.commit()
+            
+    except Exception as e:
+        session.rollback()
+        print(f"초기 데이터 삽입 실패: {e}")
+    finally:
+        session.close()
+    
     yield
     # Optional: drop tables after all tests are done
     # Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
# api 생성
- [x] 행동 수행 및 적용 (기분 변화 포함)-AI 모델 기반 기분 변화 예측(api/v1/cares/action)
- [x] api의 입력으로는 animal_id 와 action_id만을 넘겨 받음(기존 노션의 API 명세서의 내용에서 수정사항)

# ML 매개변수 계산
- [x] 편애도, 마지막 행동 이후 경과 일 수, 하루 행동 반복 수 등 행동 수행 후에 값 업데이트

- [x] 편애도: 행동을 수행하지 않은 나머지 동물의 편애도 * 0.3 한 값을 행동을 수행한 동물의 편애도에 더함

- [x] 마지막 행동 이후 경과 일 수: ML 모델의 매개변수로서의 계산에서는 CareLogs에서 동일 날짜 기준으로 조회 및 count
       -> 동물 테이블의 마지막 행동 이후 경과 일 수는 개별적으로 관리(자정에 +1 씩 모든 동물들에게 늘어나고, 행동을 수행하면 0으로 업데이트)
       -> 동물의 상태를 관리하기 위함

- [x] 하루 행동 반복 수: CareLogs에서 해당 날짜와 카테고리 기준으로 행동 반복 횟수를 계산(feed1, feed2, feed3 모두 같은 feed 카테고리에서 횟수를 계산)

- [x] service에서 action 테이블의 행동이 발생 시, 각 속성 값을 ML 매개변수 DTO에 맞게 변환함.(온힛레코딩)
       -> api의 입력으로는 animal_id 와 action_id만을 넘겨 받음 -> 이 매개변수를 ML의 입력값 형태로 변환

# 로그 생성 및 DB 업데이트
- [x] ML 감정 결과 반환 값을 정수로 내림 및 올림(양수일 경우 올림, 음수일 경우 내림)
- [x] 케어 로그(CareLogs) 테이블 생성 및 행동 수행 시 로그 생성

- [x] 행동 수행 시 사용자 보유 골드 확인 후, 골드 차감 후 거래 로그 생성

# 테스트 코 작성
- [x] 테스트 코드 작성

Closes #39 