### PR TITLE
[FEAT & TEST] 미니게임 결과 제출(돈 부여) 및 로그 생성 + 게임 결과에 따른 골드 추가 enhancement New feature or request

### DIFF
--- a/app/api/minigame/controller.py
+++ b/app/api/minigame/controller.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from fastapi import APIRouter, Depends, Header, Path
+from sqlalchemy.orm import Session
+from uuid import UUID
+from typing import Annotated
+
+from app.core.database import get_db
+from app.api.minigame.schema import MinigameResultRequest, MinigameResultResponse
+from app.api.minigame.service import process_minigame_result
+from app.core.exception import CustomException
+
+router = APIRouter(prefix="/api/v1/minigames", tags=["minigame"])
+
+@router.post("/{gameId}/result", response_model=MinigameResultResponse)
+async def submit_minigame_result(
+    gameId: Annotated[int, Path(ge=1, le=3, description="게임 ID (1, 2, 3 중 하나)")],
+    result_data: MinigameResultRequest,
+    user_id: Annotated[str, Header(alias="user-id", description="사용자 UUID")],
+    db: Session = Depends(get_db)
+):
+    # 미니게임 결과 제출 및 보상 처리
+    # - gameId: URL의 게임 ID (1, 2, 3 중 하나) - 로그에 저장됨
+    # - user-id: 헤더에 포함된 사용자 UUID
+    # - result_data: 미니게임 결과 데이터 (gameId 없음)
+    
+    # user-id 헤더 검증
+    try:
+        user_uuid = UUID(user_id)
+    except ValueError:
+        raise CustomException(message="유효하지 않은 사용자 ID 형식입니다", status=400)
+    
+    # 게임 ID 검증 (Path 검증과 중복이지만 추가 보안)
+    if gameId not in [1, 2, 3]:
+        raise CustomException(message="gameId는 1, 2, 3 중 하나여야 합니다", status=400)
+    
+    # 미니게임 결과 처리
+    return process_minigame_result(db, user_uuid, gameId, result_data)

--- a/app/api/minigame/repository.py
+++ b/app/api/minigame/repository.py
@@ -64,11 +64,6 @@ def update_user_daily_play_count(db: Session, user_id: UUID, game_id: int, play_
         play_date = date.today()
     
     try:
-        # maxPlay 확인을 위해 미니게임 정보 조회
-        minigame = get_minigame_by_id(db, game_id)
-        if not minigame:
-            raise SQLAlchemyError(f"게임 ID {game_id}를 찾을 수 없습니다")
-        
         # 기존 기록 조회
         existing_play = db.query(UserMinigamePlay).filter(
             UserMinigamePlay.userId == user_id,
@@ -77,13 +72,10 @@ def update_user_daily_play_count(db: Session, user_id: UUID, game_id: int, play_
         ).first()
         
         if existing_play:
-            # 기존 기록이 있으면 플레이 횟수 증가 (동적 maxPlay 확인)
-            if existing_play.playCount < minigame.maxPlay:
-                existing_play.playCount += 1
-                db.flush()
-                return existing_play
-            else:
-                raise SQLAlchemyError(f"플레이 횟수는 {minigame.maxPlay}회를 초과할 수 없습니다")
+            # 기존 기록이 있으면 플레이 횟수 증가
+            existing_play.playCount += 1
+            db.flush()
+            return existing_play
         else:
             # 기존 기록이 없으면 새로 생성
             new_play = UserMinigamePlay(

--- a/app/api/minigame/repository.py
+++ b/app/api/minigame/repository.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+from datetime import date
+from uuid import UUID
+from typing import Optional
+
+from app.models.minigames import Minigame
+from app.models.minigameattempts import MinigameAttempt
+from app.models.userminigameplays import UserMinigamePlay
+from app.models.user import User
+
+def get_minigame_by_id(db: Session, game_id: int) -> Optional[Minigame]:
+    # 게임 ID로 미니게임 정보 조회
+    try:
+        return db.query(Minigame).filter(Minigame.minigameId == game_id).first()
+    except SQLAlchemyError as e:
+        raise e
+
+def get_user_by_id(db: Session, user_id: UUID) -> Optional[User]:
+    # 사용자 ID로 사용자 정보 조회
+    try:
+        return db.query(User).filter(User.userId == user_id).first()
+    except SQLAlchemyError as e:
+        raise e
+
+def get_user_daily_play_count(db: Session, user_id: UUID, game_id: int, play_date: date = None) -> int:
+    # 사용자의 특정 게임 일일 플레이 횟수 조회
+    if play_date is None:
+        play_date = date.today()
+    
+    try:
+        result = db.query(UserMinigamePlay).filter(
+            UserMinigamePlay.userId == user_id,
+            UserMinigamePlay.minigameId == game_id,
+            UserMinigamePlay.playDate == play_date
+        ).first()
+        
+        return result.playCount if result else 0
+    except SQLAlchemyError as e:
+        raise e
+
+def create_minigame_attempt(db: Session, attempt_data: dict) -> MinigameAttempt:
+    # 미니게임 시도 기록 생성
+    try:
+        attempt = MinigameAttempt(
+            startedAt=attempt_data['startedAt'],
+            completionAt=attempt_data['completedAt'],
+            score=attempt_data['score'],
+            timeSpent=attempt_data['timeSpent'],
+            money=attempt_data['money'],
+            minigameId=attempt_data['gameId'],
+            userId=attempt_data['userId']
+        )
+        db.add(attempt)
+        db.flush()
+        return attempt
+    except SQLAlchemyError as e:
+        raise e
+
+def update_user_daily_play_count(db: Session, user_id: UUID, game_id: int, play_date: date = None) -> UserMinigamePlay:
+    # 사용자의 일일 플레이 횟수 업데이트
+    if play_date is None:
+        play_date = date.today()
+    
+    try:
+        # maxPlay 확인을 위해 미니게임 정보 조회
+        minigame = get_minigame_by_id(db, game_id)
+        if not minigame:
+            raise SQLAlchemyError(f"게임 ID {game_id}를 찾을 수 없습니다")
+        
+        # 기존 기록 조회
+        existing_play = db.query(UserMinigamePlay).filter(
+            UserMinigamePlay.userId == user_id,
+            UserMinigamePlay.minigameId == game_id,
+            UserMinigamePlay.playDate == play_date
+        ).first()
+        
+        if existing_play:
+            # 기존 기록이 있으면 플레이 횟수 증가 (동적 maxPlay 확인)
+            if existing_play.playCount < minigame.maxPlay:
+                existing_play.playCount += 1
+                db.flush()
+                return existing_play
+            else:
+                raise SQLAlchemyError(f"플레이 횟수는 {minigame.maxPlay}회를 초과할 수 없습니다")
+        else:
+            # 기존 기록이 없으면 새로 생성
+            new_play = UserMinigamePlay(
+                userId=user_id,
+                minigameId=game_id,
+                playDate=play_date,
+                playCount=1
+            )
+            db.add(new_play)
+            db.flush()
+            return new_play
+    except SQLAlchemyError as e:
+        raise e

--- a/app/api/minigame/schema.py
+++ b/app/api/minigame/schema.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from pydantic import BaseModel, field_validator, model_validator
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+class MinigameResultRequest(BaseModel):
+    score: Optional[int] = None
+    money: Optional[int] = None
+    timeSpent: Optional[int] = None
+    startedAt: Optional[datetime] = None
+    completedAt: Optional[datetime] = None
+
+    @field_validator('score', 'money', 'timeSpent')
+    @classmethod
+    def validate_non_negative(cls, v):
+        # null 값은 허용, 값이 있을 때만 검증
+        if v is not None and v < 0:
+            raise ValueError('값은 0 이상이어야 합니다')
+        return v
+
+    @model_validator(mode='after')
+    def validate_completion_time(self):
+        # 둘 다 값이 있을 때만 시간 순서 검증
+        if self.completedAt is not None and self.startedAt is not None:
+            if self.completedAt <= self.startedAt:
+                raise ValueError('completedAt은 startedAt보다 이후 시각이어야 합니다')
+        return self
+
+class MinigameResultData(BaseModel):
+    startedAt: Optional[datetime]
+    completedAt: Optional[datetime]
+    score: Optional[int]
+    timeSpent: Optional[int]
+    money: Optional[int]
+    gameId: int
+
+class MinigameResultResponse(BaseModel):
+    status: int
+    message: str
+    data: dict[str, MinigameResultData]
+
+    class Config:
+        from_attributes = True

--- a/app/api/minigame/service.py
+++ b/app/api/minigame/service.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+from uuid import UUID
+from datetime import date
+
+from app.api.minigame.repository import (
+    get_minigame_by_id,
+    get_user_by_id,
+    get_user_daily_play_count,
+    create_minigame_attempt,
+    update_user_daily_play_count
+)
+from app.api.user.service import process_transaction
+from app.api.minigame.schema import MinigameResultRequest, MinigameResultResponse, MinigameResultData
+from app.core.exception import CustomException
+
+def process_minigame_result(db: Session, user_id: UUID, game_id: int, result_data: MinigameResultRequest) -> MinigameResultResponse:
+    # 미니게임 결과 처리
+    try:
+        # 1. 입력값 검증
+        _validate_input(user_id, game_id, result_data)
+        
+        # 2. 게임 정보 조회
+        minigame = get_minigame_by_id(db, game_id)
+        if not minigame:
+            raise CustomException(message="존재하지 않는 게임입니다", status=404)
+        
+        # 3. 사용자 정보 조회
+        user = get_user_by_id(db, user_id)
+        if not user:
+            raise CustomException(message="사용자를 찾을 수 없습니다", status=404)
+        
+        # 4. 일일 플레이 횟수 확인
+        today = date.today()
+        current_play_count = get_user_daily_play_count(db, user_id, game_id, today)
+        
+        if current_play_count >= minigame.maxPlay:
+            raise CustomException(message="일일 플레이 횟수를 초과했습니다", status=403)
+        
+        # 5. 데이터베이스 트랜잭션 처리
+        try:
+            # 미니게임 시도 기록 생성
+            attempt_data = {
+                'startedAt': result_data.startedAt,
+                'completedAt': result_data.completedAt,
+                'score': result_data.score,
+                'timeSpent': result_data.timeSpent,
+                'money': result_data.money,
+                'gameId': game_id,
+                'userId': user_id
+            }
+            create_minigame_attempt(db, attempt_data)
+            
+            # 일일 플레이 횟수 업데이트
+            update_user_daily_play_count(db, user_id, game_id, today)
+            
+            # 재화 지급 (commit=False로 트랜잭션 관리)
+            # money가 null이 아니고 0보다 클 때만 재화 지급
+            if result_data.money is not None and result_data.money > 0:
+                process_transaction(db, user_id, result_data.money, "minigame", commit=False)
+            
+            # 모든 작업이 성공하면 커밋
+            db.commit()
+            
+            # 6. 성공 응답 반환
+            response_data = MinigameResultData(
+                startedAt=result_data.startedAt,
+                completedAt=result_data.completedAt,
+                score=result_data.score,
+                timeSpent=result_data.timeSpent,
+                money=result_data.money,
+                gameId=game_id
+            )
+            
+            # 게임 완료 여부에 따른 메시지 결정
+            if result_data.completedAt is not None:
+                message = "게임이 완료되고 보상이 지급되었습니다" if result_data.money and result_data.money > 0 else "게임이 완료되었습니다"
+            else:
+                message = "게임이 중단되었습니다"
+            
+            return MinigameResultResponse(
+                status=200,
+                message=message,
+                data={"minigameResult": response_data}
+            )
+            
+        except Exception as e:
+            db.rollback()
+            if isinstance(e, CustomException):
+                raise e
+            else:
+                raise CustomException(message="미니게임 결과 처리 중 오류가 발생했습니다", status=500)
+                
+    except CustomException as e:
+        raise e
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise CustomException(message="데이터베이스 오류가 발생했습니다", status=500)
+    except Exception as e:
+        db.rollback()
+        raise CustomException(message="서버 내부 오류가 발생했습니다", status=500)
+
+def _validate_input(user_id: UUID, game_id: int, result_data: MinigameResultRequest):
+    # 입력값 검증
+    # gameId 범위 확인 (URL의 gameId 검증)
+    if game_id not in [1, 2, 3]:
+        raise CustomException(message="gameId는 1, 2, 3 중 하나여야 합니다", status=400)
+    
+    # 음수 값 확인 (null이 아닐 때만 검증)
+    if result_data.score is not None and result_data.score < 0:
+        raise CustomException(message="score는 0 이상이어야 합니다", status=400)
+    if result_data.money is not None and result_data.money < 0:
+        raise CustomException(message="money는 0 이상이어야 합니다", status=400)
+    if result_data.timeSpent is not None and result_data.timeSpent < 0:
+        raise CustomException(message="timeSpent는 0 이상이어야 합니다", status=400)
+    
+    # 시간 순서 확인 (둘 다 null이 아닐 때만 검증)
+    if (result_data.completedAt is not None and result_data.startedAt is not None 
+        and result_data.completedAt <= result_data.startedAt):
+        raise CustomException(message="completedAt은 startedAt보다 이후 시각이어야 합니다", status=400)

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.api.pet.controller import router as pet_router
 from app.api.user.controller import router as user_router
 from app.api.ending.controller import router as ending_router
 from app.api.event.controller import router as event_router
+from app.api.minigame.controller import router as minigame_router
 
 
 # 예외 핸들러
@@ -46,6 +47,7 @@ app.include_router(pet_router)
 app.include_router(user_router)
 app.include_router(event_router)
 app.include_router(ending_router)
+app.include_router(minigame_router)
 
 # 서버가 실행되면 자동으로 "http://localhost:8000/api/v1/users/start"로 post를 보내서 유저 자동 생성
 # def call_start_api_after_server_ready():

--- a/app/models/minigameattempts.py
+++ b/app/models/minigameattempts.py
@@ -7,7 +7,7 @@ class MinigameAttempt(Base):
     __tablename__ = "MinigameAttempts"
 
     minigameAttemptId = Column(Integer, primary_key=True, index=True)
-    startedAt = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    startedAt = Column(TIMESTAMP, nullable=True)
     completionAt = Column(TIMESTAMP)
     score = Column(Integer)
     timeSpent = Column(Integer)

--- a/app/models/userminigameplays.py
+++ b/app/models/userminigameplays.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Date, ForeignKey, func, text
+from sqlalchemy import Column, Integer, Date, ForeignKey, func, text, CheckConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.core.database import Base
@@ -11,3 +11,7 @@ class UserMinigamePlay(Base):
     playCount = Column(Integer, nullable=False, server_default=text("0"))
     userId = Column(UUID(as_uuid=True), ForeignKey("Users.userId"), nullable=False)
     minigameId = Column(Integer, ForeignKey("Minigames.minigameId"), nullable=False)
+    
+    __table_args__ = (
+        CheckConstraint('playCount >= 0', name='check_play_count_non_negative'),
+    )

--- a/app/tests/minigame/test_minigame.py
+++ b/app/tests/minigame/test_minigame.py
@@ -1,0 +1,398 @@
+# -*- coding: utf-8 -*-
+import pytest
+from fastapi.testclient import TestClient
+from uuid import uuid4
+from datetime import datetime, date
+from app.models.user import User
+from app.models.minigames import Minigame
+from app.models.userminigameplays import UserMinigamePlay
+from app.models.minigameattempts import MinigameAttempt
+
+class TestMinigameResult:
+    # 미니게임 결과 API 테스트
+
+    def setup_method(self):
+        # 각 테스트 메서드 실행 전 초기 설정
+        self.test_user_id = None
+        self.test_game_id = 1
+        
+    def create_test_user(self, db_session):
+        # 테스트용 사용자 생성
+        if not self.test_user_id:
+            user = User(userId=uuid4(), money=1000)
+            db_session.add(user)
+            db_session.commit()
+            self.test_user_id = str(user.userId)
+        return self.test_user_id
+    
+    def create_test_minigames(self, db_session):
+        # 테스트용 미니게임 데이터 생성
+        # 기존 미니게임이 없으면 생성
+        if db_session.query(Minigame).count() == 0:
+            minigames = [
+                Minigame(minigameId=1, name="게임1", description="테스트 게임1", maxPlay=3),
+                Minigame(minigameId=2, name="게임2", description="테스트 게임2", maxPlay=3), 
+                Minigame(minigameId=3, name="게임3", description="테스트 게임3", maxPlay=3)
+            ]
+            db_session.add_all(minigames)
+            db_session.commit()
+
+    def test_successful_game_completion(self, client, db_session):
+        # 게임 정상 완료 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        user_id = self.create_test_user(db_session)
+        
+        # 정상 완료 요청 데이터
+        request_data = {
+            "score": 180,
+            "money": 30,
+            "timeSpent": 75,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": "2025-09-09T19:56:15Z"
+        }
+        
+        # API 호출
+        response = client.post(
+            f"/api/v1/minigames/{self.test_game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        
+        # 응답 검증
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["status"] == 200
+        assert "보상이 지급되었습니다" in response_data["message"]
+        assert response_data["data"]["minigameResult"]["score"] == 180
+        assert response_data["data"]["minigameResult"]["money"] == 30
+        assert response_data["data"]["minigameResult"]["gameId"] == self.test_game_id
+        
+        # 데이터베이스 상태 검증
+        # 1. 미니게임 시도 기록 확인
+        attempt = db_session.query(MinigameAttempt).filter(
+            MinigameAttempt.userId == user_id,
+            MinigameAttempt.minigameId == self.test_game_id
+        ).first()
+        assert attempt is not None
+        assert attempt.score == 180
+        assert attempt.money == 30
+        
+        # 2. 플레이 횟수 확인
+        play_record = db_session.query(UserMinigamePlay).filter(
+            UserMinigamePlay.userId == user_id,
+            UserMinigamePlay.minigameId == self.test_game_id,
+            UserMinigamePlay.playDate == date.today()
+        ).first()
+        assert play_record is not None
+        assert play_record.playCount == 1
+        
+        # 3. 사용자 재화 확인
+        user = db_session.query(User).filter(User.userId == user_id).first()
+        assert user.money == 1030  # 초기 1000 + 보상 30
+
+    def test_interrupted_game_with_null_values(self, client, db_session):
+        # 게임 중단 (null 값) 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        user_id = self.create_test_user(db_session)
+        
+        # 게임 중단 요청 데이터 (startedAt 제외 모든 값이 null)
+        request_data = {
+            "score": None,
+            "money": None,
+            "timeSpent": None,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": None
+        }
+        
+        # API 호출
+        response = client.post(
+            f"/api/v1/minigames/{self.test_game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        
+        # 디버깅용 응답 내용 출력
+        if response.status_code != 200:
+            print(f"Response status: {response.status_code}")
+            print(f"Response body: {response.text}")
+        
+        # 응답 검증
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["status"] == 200
+        assert response_data["message"] == "게임이 중단되었습니다"
+        assert response_data["data"]["minigameResult"]["score"] is None
+        assert response_data["data"]["minigameResult"]["money"] is None
+        assert response_data["data"]["minigameResult"]["gameId"] == self.test_game_id
+        
+        # 데이터베이스 상태 검증
+        # 1. 미니게임 시도 기록 확인 (null 값들이 저장됨)
+        attempt = db_session.query(MinigameAttempt).filter(
+            MinigameAttempt.userId == user_id,
+            MinigameAttempt.minigameId == self.test_game_id
+        ).first()
+        assert attempt is not None
+        assert attempt.score is None
+        assert attempt.money is None
+        assert attempt.timeSpent is None
+        assert attempt.completionAt is None
+        
+        # 2. 플레이 횟수는 증가함 (중단되어도 시도로 카운트)
+        play_record = db_session.query(UserMinigamePlay).filter(
+            UserMinigamePlay.userId == user_id,
+            UserMinigamePlay.minigameId == self.test_game_id,
+            UserMinigamePlay.playDate == date.today()
+        ).first()
+        assert play_record is not None
+        assert play_record.playCount == 1
+        
+        # 3. 사용자 재화는 변화 없음 (보상 없음)
+        user = db_session.query(User).filter(User.userId == user_id).first()
+        assert user.money == 1000  # 초기값 그대로
+
+    def test_partial_null_values(self, client, db_session):
+        # 일부 값만 null인 경우 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        user_id = self.create_test_user(db_session)
+        
+        # 일부 값만 null인 요청 데이터
+        request_data = {
+            "score": 100,
+            "money": None,  # 보상 없음
+            "timeSpent": 60,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": "2025-09-09T19:56:00Z"
+        }
+        
+        # API 호출
+        response = client.post(
+            f"/api/v1/minigames/{self.test_game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        
+        # 응답 검증
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["message"] == "게임이 완료되었습니다"  # 보상 없음
+        assert response_data["data"]["minigameResult"]["score"] == 100
+        assert response_data["data"]["minigameResult"]["money"] is None
+        
+        # 사용자 재화는 변화 없음 (money가 null이므로 보상 없음)
+        user = db_session.query(User).filter(User.userId == user_id).first()
+        assert user.money == 1000
+
+    def test_daily_play_limit_exceeded(self, client, db_session):
+        # 일일 플레이 횟수 초과 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        user_id = self.create_test_user(db_session)
+        
+        # 게임 ID 2 사용 (maxPlay = 3)
+        game_id = 2
+        
+        # 첫 번째 플레이
+        request_data = {
+            "score": 100,
+            "money": 10,
+            "timeSpent": 60,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": "2025-09-09T19:56:00Z"
+        }
+        
+        response1 = client.post(
+            f"/api/v1/minigames/{game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        assert response1.status_code == 200
+        
+        # 두 번째 플레이
+        response2 = client.post(
+            f"/api/v1/minigames/{game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        assert response2.status_code == 200
+        
+        # 세 번째 플레이 
+        response3 = client.post(
+            f"/api/v1/minigames/{game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        assert response3.status_code == 200
+        
+        # 네 번째 플레이 (초과)
+        response4 = client.post(
+            f"/api/v1/minigames/{game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        assert response4.status_code == 403
+        response_data = response4.json()
+        assert "일일 플레이 횟수를 초과했습니다" in response_data["message"]
+
+    def test_invalid_game_id(self, client, db_session):
+        # 잘못된 게임 ID 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        user_id = self.create_test_user(db_session)
+        
+        request_data = {
+            "score": 100,
+            "money": 10,
+            "timeSpent": 60,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": "2025-09-09T19:56:00Z"
+        }
+        
+        # 잘못된 게임 ID (4)
+        response = client.post(
+            "/api/v1/minigames/4/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        assert response.status_code == 422  # FastAPI Path validation error
+
+    def test_invalid_user_id(self, client, db_session):
+        # 잘못된 사용자 ID 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        
+        request_data = {
+            "score": 100,
+            "money": 10,
+            "timeSpent": 60,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": "2025-09-09T19:56:00Z"
+        }
+        
+        # 잘못된 UUID 형식
+        response = client.post(
+            f"/api/v1/minigames/{self.test_game_id}/result",
+            json=request_data,
+            headers={"user-id": "invalid-uuid"}
+        )
+        assert response.status_code == 400
+        response_data = response.json()
+        assert "유효하지 않은 사용자 ID 형식입니다" in response_data["message"]
+
+    def test_nonexistent_user(self, client, db_session):
+        # 존재하지 않는 사용자 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        
+        request_data = {
+            "score": 100,
+            "money": 10,
+            "timeSpent": 60,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": "2025-09-09T19:56:00Z"
+        }
+        
+        # 존재하지 않는 UUID
+        fake_user_id = str(uuid4())
+        response = client.post(
+            f"/api/v1/minigames/{self.test_game_id}/result",
+            json=request_data,
+            headers={"user-id": fake_user_id}
+        )
+        assert response.status_code == 404
+        response_data = response.json()
+        assert "사용자를 찾을 수 없습니다" in response_data["message"]
+
+    def test_negative_values_validation(self, client, db_session):
+        # 음수 값 검증 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        user_id = self.create_test_user(db_session)
+        
+        # 음수 값이 포함된 요청 데이터
+        request_data = {
+            "score": -10,  # 음수
+            "money": 10,
+            "timeSpent": 60,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": "2025-09-09T19:56:00Z"
+        }
+        
+        response = client.post(
+            f"/api/v1/minigames/{self.test_game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        assert response.status_code == 422  # Pydantic validation error
+
+    def test_invalid_time_order(self, client, db_session):
+        # 잘못된 시간 순서 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        user_id = self.create_test_user(db_session)
+        
+        # completedAt이 startedAt보다 이전인 요청 데이터
+        request_data = {
+            "score": 100,
+            "money": 10,
+            "timeSpent": 60,
+            "startedAt": "2025-09-09T19:56:00Z",
+            "completedAt": "2025-09-09T19:55:00Z"  # 시작 시간보다 이전
+        }
+        
+        response = client.post(
+            f"/api/v1/minigames/{self.test_game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        assert response.status_code == 422  # Pydantic validation error
+
+    def test_missing_user_id_header(self, client, db_session):
+        # user-id 헤더 누락 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        
+        request_data = {
+            "score": 100,
+            "money": 10,
+            "timeSpent": 60,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": "2025-09-09T19:56:00Z"
+        }
+        
+        # user-id 헤더 없이 요청
+        response = client.post(
+            f"/api/v1/minigames/{self.test_game_id}/result",
+            json=request_data
+        )
+        assert response.status_code == 422  # FastAPI validation error
+
+    def test_zero_money_reward(self, client, db_session):
+        # 보상이 0원인 경우 테스트
+        # 초기 데이터 설정
+        self.create_test_minigames(db_session)
+        user_id = self.create_test_user(db_session)
+        
+        request_data = {
+            "score": 100,
+            "money": 0,  # 보상 0원
+            "timeSpent": 60,
+            "startedAt": "2025-09-09T19:55:00Z",
+            "completedAt": "2025-09-09T19:56:00Z"
+        }
+        
+        response = client.post(
+            f"/api/v1/minigames/{self.test_game_id}/result",
+            json=request_data,
+            headers={"user-id": user_id}
+        )
+        
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["message"] == "게임이 완료되었습니다"  # 보상 없음 메시지
+        
+        # 사용자 재화는 변화 없음
+        user = db_session.query(User).filter(User.userId == user_id).first()
+        assert user.money == 1000


### PR DESCRIPTION
  1. 작업 내용

  - 미니게임 결과 처리 API 엔드포인트 추가
     - POST /api/v1/minigames/{gameId}/result를 구현하여 클라이언트에서 전송된 미니게임 결과를 처리합니다.
     - process_minigame_result 서비스 함수를 통해 비즈니스 로직(결과 기록, 보상 지급, 플레이 횟수 관리)을 캡슐화했습니다.

  - 주요 로직:
     - 게임 완료 시: MinigameAttempt와 MoneyTransaction에 기록을 추가하고, 사용자의 money를 업데이트합니다.
     - 게임 중단 시: MinigameAttempt에 중단 기록만 남기고, 재화는 변경하지 않습니다.
     - UserMinigamePlay 테이블을 통해 사용자의 일일 플레이 횟수를 추적하고, 최대 횟수(maxPlay)를 초과하면 403 Forbidden 오류를 반환합니다.(게임 완료 시 & 게임 중단 시)

  2. 테스트 코드 추가

   - app/tests/minigame/test_minigame.py에 새로운 API를 검증하기 위한 pytest 테스트 코드를 추가했습니다.
   - 주요 테스트 시나리오:
     - 성공 케이스: 게임 정상 완료 및 보상 지급 검증
     - 중단 케이스: 게임 중단 시 재화 변경 없이 기록만 되는지 검증
     - 횟수 제한: 일일 플레이 횟수 초과 시 요청이 거부되는지 검증
     - 예외 처리:
       - 잘못된 gameId 또는 user-id 형식
       - 존재하지 않는 사용자
       - Pydantic 모델 유효성 검사 (음수 값, 잘못된 시간 순서 등)

  3. 의존성 추가

   - 테스트 환경 구성을 위해 다음 패키지를 설치했습니다.
     - pytest
     - fastapi
     - httpx
     - pandas
Closes: #45 