### PR TITLE
[Bug] CheckConstraint의 컬럼명 참조로 인한 데이터베이스 오류

### DIFF
--- a/app/models/userminigameplays.py
+++ b/app/models/userminigameplays.py
@@ -13,5 +13,5 @@ class UserMinigamePlay(Base):
     minigameId = Column(Integer, ForeignKey("Minigames.minigameId"), nullable=False)
     
     __table_args__ = (
-        CheckConstraint('playCount >= 0', name='check_play_count_non_negative'),
+        CheckConstraint('"playCount" >= 0', name='check_play_count_non_negative'),
     )


### PR DESCRIPTION
## 어떤 기능인가요?

애플리케이션 시작 시 SQLAlchemy가 테이블을 생성하는 과정에서 CheckConstraint가 특정 컬럼을 찾지 못해 ProgrammingError가 발생하며 서버가 실행되지 않는 버그를 수정합니다.

##  어떻게 구현하면 좋을까요?

오류가 발생하는 SQLAlchemy 모델의 __table_args__에 정의된 CheckConstraint 내부의 컬럼명에 큰따옴표(")를 추가합니다.

기존: CheckConstraint('playCount >= 0', ...)

변경: CheckConstraint('"playCount" >= 0', ...)

PostgreSQL이 따옴표 없는 식별자를 소문자로 처리하는 문제를 해결하고, 대소문자를 구분하는 컬럼명을 명시적으로 참조하도록 수정합니다.

##  작업 TODO

- [ ] UserMinigamePlays 모델에서 CheckConstraint 로직 확인
- [ ] 제약조건 내 playCount 컬럼명에 큰따옴표 추가
- [ ] 애플리케이션 재시작 후 테이블이 정상적으로 생성되는지 검증

## 다른 방법이 있을까요?

이 기능의 다른 해결 방법이나 대체 아이디어가 있다면 알려주세요.

##  추가 정보

closes #50
