### PR TITLE
[FEAT] Users 테이블 초기화 시 CareLogs 삭제

### DIFF
--- a/app/api/ending/repository.py
+++ b/app/api/ending/repository.py
@@ -9,16 +9,23 @@ from app.models.attendance import AttendanceLog
 from app.models.birthday import BirthdayReward
 from app.models.minigameattempts import MinigameAttempt
 from app.models.userminigameplays import UserMinigamePlay
+from app.models.action_log import ActionLog
 
 def delete_user_and_related_data(db: Session, user_id: UUID):
+    # 미니게임 관련 데이터 삭제
     db.execute(delete(MinigameAttempt).where(MinigameAttempt.userId == user_id))
-    db.execute(delete(UserMinigamePlay).where(Animal.userId == user_id))
+    db.execute(delete(UserMinigamePlay).where(UserMinigamePlay.userId == user_id))
 
-    # 연관 데이터 삭제 (동물, 트랜잭션, 출석, 생일 보상, 유저)
+    # 케어 로그 삭제
+    db.execute(delete(ActionLog).where(ActionLog.userId == user_id))
+
+    # 연관 데이터 삭제 (동물, 트랜잭션, 출석, 생일 보상)
     db.execute(delete(Animal).where(Animal.userId == user_id))
     db.execute(delete(MoneyTransaction).where(MoneyTransaction.userId == user_id))
     db.execute(delete(AttendanceLog).where(AttendanceLog.userId == user_id))
     db.execute(delete(BirthdayReward).where(BirthdayReward.userId == user_id))
+
+    # 마지막으로 유저 삭제
     db.execute(delete(User).where(User.userId == user_id))
     db.commit()
 


### PR DESCRIPTION
## 어떤 기능인가요?

현재 Users 테이블 초기화 시 외래키 제약 조건으로 인해 CareLogs 테이블을 삭제하지 않으면 무결성이 발생하여 삭제되지 않습니다.
이번 이슈에서는 CareLogs 테이블도 같이 삭제하도록 하는 로직을 추가하였습니다.

## 어떻게 구현하면 좋을까요?

구현 아이디어가 있다면 적어주세요.

## 작업 TODO

- [x] User 테이블 초기화 시 CareLogs 테이블도 CASCADE.

## 다른 방법이 있을까요?

이 기능의 다른 해결 방법이나 대체 아이디어가 있다면 알려주세요.

##  추가 정보

closes #54